### PR TITLE
Add support for JsonResources (and any other Arrayables/JsonSerializables)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,11 @@ Optionally, the trait could be imported within a base controller.
 
 ## Available methods
 
-
 #### `respondNotFound(string|Exception $message, ?string $key = 'error')`
 
 Returns a `404` HTTP status code, an excpetion object can optionally be passed.
 
-#### `respondWithSuccess(?array $contents = [])`
+#### `respondWithSuccess(array|Arrayable|JsonSerializable|null $contents = [])`
 
 Returns a `200` HTTP status code
 
@@ -71,11 +70,11 @@ Returns a `403` HTTP status code
 
 Returns a `400` HTTP status code
 
-#### `respondCreated(?array $data = [])`
+#### `respondCreated(array|Arrayable|JsonSerializable|null $data = [])`
 
 Returns a `201` HTTP status code, with response optional data
 
-#### `respondNoContent(?array $data = [])`
+#### `respondNoContent(array|Arrayable|JsonSerializable|null $data = [])`
 
 Returns a `204` HTTP status code, with optional response data. Strictly speaking, the response body should be empty. However, functionality to optionally return data was added to handle legacy projects. Within your own projects, you can simply call the method, omitting parameters, to generate a correct `204` response i.e. `return $this->respondNoContent()` 
 
@@ -93,7 +92,11 @@ I wanted to add a simple trait that kept this consistent, in this case:
 
 `$this->respondError('Ouch')`
 
-This package is intended to be used **alongside** Laravel's  [API resources](https://laravel.com/docs/8.x/eloquent-resources) and in no way replaces them.
+This package is intended to be used **alongside** Laravel's  [API resources](https://laravel.com/docs/8.x/eloquent-resources) and in no way replaces them:
+
+```php
+$this->respondCreated(PostResource::make($post));
+```
 
 ## Contribution
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
   ],
   "require": {
     "php": "^7.4 | ^8.0",
-    "illuminate/support": "^6.0|^7.0|^8.0"
+    "illuminate/support": "^6.0|^7.0|^8.0",
+    "ext-json": "*"
   },
   "require-dev": {
     "orchestra/testbench": "^4.0|^5.0|^6.0",

--- a/src/ApiResponseHelpers.php
+++ b/src/ApiResponseHelpers.php
@@ -39,7 +39,7 @@ trait ApiResponseHelpers
      */
     public function respondWithSuccess($contents = []): JsonResponse
     {
-        $contents = $this->normalizedArray($contents);
+        $contents = $this->morphToArray($contents);
 
         $data = [] === $contents
             ? ['success' => true]
@@ -82,7 +82,7 @@ trait ApiResponseHelpers
      */
     public function respondCreated($data = []): JsonResponse
     {
-        $data = $this->normalizedArray($data);
+        $data = $this->morphToArray($data);
 
         return $this->apiResponse($data, Response::HTTP_CREATED);
     }
@@ -120,7 +120,7 @@ trait ApiResponseHelpers
      */
     public function respondNoContent($data = []): JsonResponse
     {
-        $data = $this->normalizedArray($data);
+        $data = $this->morphToArray($data);
 
         return $this->apiResponse($data, Response::HTTP_NO_CONTENT);
     }
@@ -134,7 +134,8 @@ trait ApiResponseHelpers
      * @param array|Arrayable|JsonSerializable|null $data
      * @return array|null
      */
-    private function normalizedArray($data) {
+    private function morphToArray($data)
+    {
         if ($data instanceof Arrayable) {
             return $data->toArray();
         }

--- a/src/ApiResponseHelpers.php
+++ b/src/ApiResponseHelpers.php
@@ -39,11 +39,7 @@ trait ApiResponseHelpers
      */
     public function respondWithSuccess($contents = []): JsonResponse
     {
-        if ($contents instanceof Arrayable) {
-            $contents = $contents->toArray();
-        } elseif ($contents instanceof JsonSerializable) {
-            $contents = $contents->jsonSerialize();
-        }
+        $contents = $this->normalizedArray($contents);
 
         $data = [] === $contents
             ? ['success' => true]
@@ -86,11 +82,7 @@ trait ApiResponseHelpers
      */
     public function respondCreated($data = []): JsonResponse
     {
-        if ($data instanceof Arrayable) {
-            $data = $data->toArray();
-        } elseif ($data instanceof JsonSerializable) {
-            $data = $data->jsonSerialize();
-        }
+        $data = $this->normalizedArray($data);
 
         return $this->apiResponse($data, Response::HTTP_CREATED);
     }
@@ -128,11 +120,7 @@ trait ApiResponseHelpers
      */
     public function respondNoContent($data = []): JsonResponse
     {
-        if ($data instanceof Arrayable) {
-            $data = $data->toArray();
-        } elseif ($data instanceof JsonSerializable) {
-            $data = $data->jsonSerialize();
-        }
+        $data = $this->normalizedArray($data);
 
         return $this->apiResponse($data, Response::HTTP_NO_CONTENT);
     }
@@ -140,5 +128,21 @@ trait ApiResponseHelpers
     private function apiResponse(array $data, int $code = 200): JsonResponse
     {
         return response()->json($data, $code);
+    }
+
+    /**
+     * @param array|Arrayable|JsonSerializable|null $data
+     * @return array|null
+     */
+    private function normalizedArray($data) {
+        if ($data instanceof Arrayable) {
+            return $data->toArray();
+        }
+
+        if ($data instanceof JsonSerializable) {
+            return $data->jsonSerialize();
+        }
+
+        return $data;
     }
 }

--- a/src/ApiResponseHelpers.php
+++ b/src/ApiResponseHelpers.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace F9Web;
 
 use Exception;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Http\JsonResponse;
+use JsonSerializable;
 use Symfony\Component\HttpFoundation\Response;
 
 use function response;
@@ -32,8 +34,17 @@ trait ApiResponseHelpers
         );
     }
 
-    public function respondWithSuccess(?array $contents = []): JsonResponse
+    /**
+     * @param array|Arrayable|JsonSerializable|null $contents
+     */
+    public function respondWithSuccess($contents = []): JsonResponse
     {
+        if ($contents instanceof Arrayable) {
+            $contents = $contents->toArray();
+        } elseif ($contents instanceof JsonSerializable) {
+            $contents = $contents->jsonSerialize();
+        }
+
         $data = [] === $contents
             ? ['success' => true]
             : $contents;
@@ -70,8 +81,17 @@ trait ApiResponseHelpers
         );
     }
 
-    public function respondCreated(?array $data = []): JsonResponse
+    /**
+     * @param array|Arrayable|JsonSerializable|null $data
+     */
+    public function respondCreated($data = []): JsonResponse
     {
+        if ($data instanceof Arrayable) {
+            $data = $data->toArray();
+        } elseif ($data instanceof JsonSerializable) {
+            $data = $data->jsonSerialize();
+        }
+
         return $this->apiResponse($data, Response::HTTP_CREATED);
     }
     
@@ -102,9 +122,18 @@ trait ApiResponseHelpers
           Response::HTTP_I_AM_A_TEAPOT
         );
     }
-    
-    public function respondNoContent(?array $data = []): JsonResponse
+
+    /**
+     * @param array|Arrayable|JsonSerializable|null $data
+     */
+    public function respondNoContent($data = []): JsonResponse
     {
+        if ($data instanceof Arrayable) {
+            $data = $data->toArray();
+        } elseif ($data instanceof JsonSerializable) {
+            $data = $data->jsonSerialize();
+        }
+
         return $this->apiResponse($data, Response::HTTP_NO_CONTENT);
     }
 

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -125,6 +125,7 @@ class ResponseTest extends TestCase
         $response = $this->service->respondCreated(new Collection([ 'id' => 123, 'title' => 'ABC' ]));
         self::assertJsonStringEqualsJsonString('{"id":123,"title":"ABC"}', $response->getContent());
         self::assertEquals([ 'id' => 123, 'title' => 'ABC' ], $response->getData(true));
+        self::assertEquals(Response::HTTP_CREATED, $response->getStatusCode());
     }
 
     public function testRespondFailedValidation(): void

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -7,6 +7,7 @@ namespace F9Web\ApiResponseHelpers\Tests;
 use DomainException;
 use F9Web\ApiResponseHelpers;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Collection;
 use Symfony\Component\HttpFoundation\Response;
 
 class ResponseTest extends TestCase
@@ -48,6 +49,10 @@ class ResponseTest extends TestCase
         self::assertEquals(['success' => true], $response->getData(true));
 
         $response = $this->service->respondWithSuccess(['super' => 'response', 'yes' => 123]);
+        self::assertJsonStringEqualsJsonString('{"super":"response","yes":123}', $response->getContent());
+        self::assertEquals(['super' => 'response', 'yes' => 123], $response->getData(true));
+
+        $response = $this->service->respondWithSuccess(new Collection(['super' => 'response', 'yes' => 123]));
         self::assertJsonStringEqualsJsonString('{"super":"response","yes":123}', $response->getContent());
         self::assertEquals(['super' => 'response', 'yes' => 123], $response->getData(true));
     }
@@ -112,6 +117,14 @@ class ResponseTest extends TestCase
         self::assertEquals(Response::HTTP_CREATED, $response->getStatusCode());
         self::assertJsonStringEqualsJsonString('[]', $response->getContent());
         self::assertEquals([], $response->getData(true));
+
+        $response = $this->service->respondCreated([ 'id' => 123, 'title' => 'ABC' ]);
+        self::assertJsonStringEqualsJsonString('{"id":123,"title":"ABC"}', $response->getContent());
+        self::assertEquals([ 'id' => 123, 'title' => 'ABC' ], $response->getData(true));
+
+        $response = $this->service->respondCreated(new Collection([ 'id' => 123, 'title' => 'ABC' ]));
+        self::assertJsonStringEqualsJsonString('{"id":123,"title":"ABC"}', $response->getContent());
+        self::assertEquals([ 'id' => 123, 'title' => 'ABC' ], $response->getData(true));
     }
 
     public function testRespondFailedValidation(): void


### PR DESCRIPTION
Here's what I was envisioning with #9 ! This is basically the same thing that also happens inside `JsonResource`s:

https://github.com/laravel/framework/blob/76380cfc6a675d9ad0b1714d6268de13ce406758/src/Illuminate/Http/Resources/Json/JsonResource.php#L98-L102