### PR TITLE
Allow overriding of default response data

### DIFF
--- a/src/ApiResponseHelpers.php
+++ b/src/ApiResponseHelpers.php
@@ -39,7 +39,7 @@ trait ApiResponseHelpers
 
         $data = [] === $contents
             ? ['success' => true]
-            : $contents;
+            : array_merge(['success' => true], $contents);
 
         return $this->apiResponse($data);
     }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -71,25 +71,39 @@ class ResponseTest extends TestCase
             ['success' => true],
           ],
 
+          'respondWithSuccess(), custom success value' => [
+            'respondWithSuccess',
+            [['success' => 'maybe']],
+            Response::HTTP_OK,
+            ['success' => 'maybe'],
+          ],
+
           'respondWithSuccess(), custom response data' => [
             'respondWithSuccess',
             [['order' => 237]],
             Response::HTTP_OK,
-            ['order' => 237],
+            ['success' => true, 'order' => 237],
+          ],
+
+          'respondWithSuccess(), custom response data and custom success value' => [
+            'respondWithSuccess',
+            [['success' => 'maybe', 'order' => 237]],
+            Response::HTTP_OK,
+            ['success' => 'maybe', 'order' => 237],
           ],
 
           'respondWithSuccess(), nested custom response data' => [
             'respondWithSuccess',
             [['order' => 237, 'customer' => ['name' => 'Jason Bourne']]],
             Response::HTTP_OK,
-            ['order' => 237, 'customer' => ['name' => 'Jason Bourne']],
+            ['success' => true, 'order' => 237, 'customer' => ['name' => 'Jason Bourne']],
           ],
 
           'respondWithSuccess(), collection' => [
             'respondWithSuccess',
             [new Collection(['invoice' => 23, 'status' => 'pending'])],
             Response::HTTP_OK,
-            ['invoice' => 23, 'status' => 'pending'],
+            ['success' => true, 'invoice' => 23, 'status' => 'pending'],
           ],
 
           'respondOk()' => [


### PR DESCRIPTION
merging the response array instead of overwriting it would make it possible to just add data. Like this:


```
$this->respondWithSuccess(['token' => $superSecret]);

----------

{
  "success": true,
  "token": "n8tJiZrIS8"
}
```

you could still overwrite the success value:

```
return $this->respondWithSuccess(['success' => "maybe", 'token' => superSecret]);

----------

{
  "success": "maybe",
  "token": "Ru4nL9IxE3"
}
```