### PR TITLE
Implemented success response with an empty array

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,12 @@ Returns a `201` HTTP status code, with response optional data
 
 Returns a `204` HTTP status code, with optional response data. Strictly speaking, the response body should be empty. However, functionality to optionally return data was added to handle legacy projects. Within your own projects, you can simply call the method, omitting parameters, to generate a correct `204` response i.e. `return $this->respondNoContent()`
 
-#### `setDefaultSuccessResponse(?array $content = null)`
+#### `setDefaultSuccessResponse(?array $content = null): self`
 
-Allows to replace default `['success' => true]` response returned by `respondWithSuccess` with `$content`. You can call it in constructor to change default for all calls or call it in place where you need it. This is a fluent method returning `$this` which lets you chain calls.
+Optionally, replace the default `['success' => true]` response returned by `respondWithSuccess` with `$content`. This method can be called from the constructor (to change default for all calls), a base API controller or place when required. 
 
-Example:
+`setDefaultSuccessResponse` is a fluent method returning `$this` allows for chained methods calls:
+
 ```php
 $users = collect([10, 20, 30, 40]);
 
@@ -95,7 +96,9 @@ public function __construct()
 {
     $this->setDefaultSuccessResponse([]);
 }
+
 ...
+
 $users = collect([10, 20, 30, 40]);
 
 return $this->respondWithSuccess($users);

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ Optionally, the trait could be imported within a base controller.
 
 Returns a `404` HTTP status code, an exception object can optionally be passed.
 
-#### `respondWithSuccess(array|Arrayable|JsonSerializable|null $contents = [])`
+#### `respondWithSuccess(array|Arrayable|JsonSerializable|null $contents = null)`
 
-Returns a `200` HTTP status code
+Returns a `200` HTTP status code, optionally `$contents` to return as json can be passed. By default returns `['success' => true]`.
 
 #### `respondOk(string $message)`
 
@@ -70,13 +70,37 @@ Returns a `403` HTTP status code
 
 Returns a `400` HTTP status code
 
-#### `respondCreated(array|Arrayable|JsonSerializable|null $data = [])`
+#### `respondCreated(array|Arrayable|JsonSerializable|null $data = null)`
 
 Returns a `201` HTTP status code, with response optional data
 
-#### `respondNoContent(array|Arrayable|JsonSerializable|null $data = [])`
+#### `respondNoContent(array|Arrayable|JsonSerializable|null $data = null)`
 
 Returns a `204` HTTP status code, with optional response data. Strictly speaking, the response body should be empty. However, functionality to optionally return data was added to handle legacy projects. Within your own projects, you can simply call the method, omitting parameters, to generate a correct `204` response i.e. `return $this->respondNoContent()`
+
+#### `setDefaultSuccessResponse(?array $content = null)`
+
+Allows to replace default `['success' => true]` response returned by `respondWithSuccess` with `$content`. You can call it in constructor to change default for all calls or call it in place where you need it. This is a fluent method returning `$this` which lets you chain calls.
+
+Example:
+```php
+$users = collect([10, 20, 30, 40]);
+
+return $this->setDefaultSuccessResponse([])->respondWithSuccess($users);
+```
+
+Or
+```php
+public function __construct()
+{
+    $this->setDefaultSuccessResponse([]);
+}
+...
+$users = collect([10, 20, 30, 40]);
+
+return $this->respondWithSuccess($users);
+```
+
 
 ## Use with additional object types
 
@@ -148,4 +172,3 @@ If you discover any security related issues, please email rob@f9web.co.uk instea
 ## License
 
 The MIT License (MIT). Please see [License File](LICENSE) for more information.
-

--- a/src/ApiResponseHelpers.php
+++ b/src/ApiResponseHelpers.php
@@ -135,7 +135,6 @@ trait ApiResponseHelpers
     }
 
     /**
-     * @internal
      * @param array|Arrayable|JsonSerializable|null $data
      * @return array|null
      */
@@ -153,7 +152,6 @@ trait ApiResponseHelpers
     }
 
     /**
-     * @internal
      * @param string|\Exception $message
      * @return string
      */

--- a/src/ApiResponseHelpers.php
+++ b/src/ApiResponseHelpers.php
@@ -36,7 +36,7 @@ trait ApiResponseHelpers
     /**
      * @param array|Arrayable|JsonSerializable|null $contents
      */
-    public function respondWithSuccess($contents = []): JsonResponse
+    public function respondWithSuccess($contents = null): JsonResponse
     {
         $contents = $this->morphToArray($contents) ?? [];
 
@@ -85,8 +85,9 @@ trait ApiResponseHelpers
     /**
      * @param array|Arrayable|JsonSerializable|null $data
      */
-    public function respondCreated($data = []): JsonResponse
+    public function respondCreated($data = null): JsonResponse
     {
+        $data ??= [];
         return $this->apiResponse(
           $this->morphToArray($data),
           Response::HTTP_CREATED
@@ -120,8 +121,9 @@ trait ApiResponseHelpers
     /**
      * @param array|Arrayable|JsonSerializable|null $data
      */
-    public function respondNoContent($data = []): JsonResponse
+    public function respondNoContent($data = null): JsonResponse
     {
+        $data ??= [];
         $data = $this->morphToArray($data);
 
         return $this->apiResponse($data, Response::HTTP_NO_CONTENT);

--- a/src/ApiResponseHelpers.php
+++ b/src/ApiResponseHelpers.php
@@ -14,7 +14,6 @@ use function response;
 
 trait ApiResponseHelpers
 {
-
     private ?array $_api_helpers_defaultSuccessData = ['success' => true];
 
     /**
@@ -47,7 +46,7 @@ trait ApiResponseHelpers
         return $this->apiResponse($data);
     }
 
-    public function setDefaultSuccessResponse(?array $content = null)
+    public function setDefaultSuccessResponse(?array $content = null): self
     {
         $this->_api_helpers_defaultSuccessData = $content ?? [];
         return $this;

--- a/src/ApiResponseHelpers.php
+++ b/src/ApiResponseHelpers.php
@@ -14,6 +14,9 @@ use function response;
 
 trait ApiResponseHelpers
 {
+
+    private ?array $_api_helpers_defaultSuccessData = ['success' => true];
+
     /**
      * @param string|\Exception $message
      * @param  string|null  $key
@@ -38,10 +41,16 @@ trait ApiResponseHelpers
         $contents = $this->morphToArray($contents) ?? [];
 
         $data = [] === $contents
-            ? ['success' => true]
+            ? $this->_api_helpers_defaultSuccessData
             : $contents;
 
         return $this->apiResponse($data);
+    }
+
+    public function setDefaultSuccessResponse(?array $content = null)
+    {
+        $this->_api_helpers_defaultSuccessData = $content ?? [];
+        return $this;
     }
 
     public function respondOk(string $message): JsonResponse

--- a/src/ApiResponseHelpers.php
+++ b/src/ApiResponseHelpers.php
@@ -35,7 +35,7 @@ trait ApiResponseHelpers
      */
     public function respondWithSuccess($contents = []): JsonResponse
     {
-        $contents = $this->morphToArray($contents);
+        $contents = $this->morphToArray($contents) ?? [];
 
         $data = [] === $contents
             ? ['success' => true]

--- a/src/ApiResponseHelpers.php
+++ b/src/ApiResponseHelpers.php
@@ -124,6 +124,7 @@ trait ApiResponseHelpers
     }
 
     /**
+     * @internal
      * @param array|Arrayable|JsonSerializable|null $data
      * @return array|null
      */
@@ -141,6 +142,7 @@ trait ApiResponseHelpers
     }
 
     /**
+     * @internal
      * @param string|\Exception $message
      * @return string
      */

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -41,6 +41,19 @@ class ResponseTest extends TestCase
         self::assertJsonStringEqualsJsonString(json_encode($data, JSON_THROW_ON_ERROR), $response->getContent());
     }
 
+    /**
+     * @dataProvider successDefaultsDataProvider
+     * @throws JsonException
+     */
+    public function testSuccessResponseDefaults(?array $default, $args, int $code, array $data): void
+    {
+        $response = $this->service->setDefaultSuccessResponse($default)->respondWithSuccess($args);
+        self::assertInstanceOf(JsonResponse::class, $response);
+        self::assertSame($code, $response->getStatusCode());
+        self::assertSame($data, $response->getData(true));
+        self::assertJsonStringEqualsJsonString(json_encode($data, JSON_THROW_ON_ERROR), $response->getContent());
+    }
+
     public function basicResponsesDataProvider(): array
     {
         return [
@@ -319,6 +332,42 @@ class ResponseTest extends TestCase
             Response::HTTP_NO_CONTENT,
             ['invoice' => 23, 'status' => 'pending'],
           ],
+        ];
+    }
+
+    public function successDefaultsDataProvider(): array
+    {
+        return [
+            'respondWithSuccess(), default empty array' => [
+                'default' => [],
+                'args' => [],
+                'code' => Response::HTTP_OK,
+                'data' => [],
+            ],
+            'respondWithSuccess(), default null' => [
+                'default' => null,
+                'args' => [],
+                'code' => Response::HTTP_OK,
+                'data' => [],
+            ],
+            'respondWithSuccess(), default null, null response' => [
+                'default' => null,
+                'args' => null,
+                'code' => Response::HTTP_OK,
+                'data' => [],
+            ],
+            'respondWithSuccess(), default non-empty array' => [
+                'default' => ['message' => 'Task successful!'],
+                'args' => [],
+                'code' => Response::HTTP_OK,
+                'data' => ['message' => 'Task successful!'],
+            ],
+            'respondWithSuccess(), default non-empty array, custom response data' => [
+                'default' => ['message' => 'Task successful!'],
+                'args' => ['numbers' => [1, 2, 3]],
+                'code' => Response::HTTP_OK,
+                'data' => ['numbers' => [1, 2, 3]],
+            ]
         ];
     }
 }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -36,8 +36,8 @@ class ResponseTest extends TestCase
         /** @var \Illuminate\Http\JsonResponse $response */
         $response = call_user_func_array([$this->service, $method], $args);
         self::assertInstanceOf(JsonResponse::class, $response);
-        self::assertEquals($code, $response->getStatusCode());
-        self::assertEquals($data, $response->getData(true));
+        self::assertSame($code, $response->getStatusCode());
+        self::assertSame($data, $response->getData(true));
         self::assertJsonStringEqualsJsonString(json_encode($data, JSON_THROW_ON_ERROR), $response->getContent());
     }
 

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace F9Web\ApiResponseHelpers\Tests;
 
 use F9Web\ApiResponseHelpers;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Http\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use JsonException;
@@ -74,6 +75,13 @@ class ResponseTest extends TestCase
             ['success' => true],
           ],
 
+          'respondWithSuccess(), null response data' => [
+            'respondWithSuccess',
+            [null],
+            Response::HTTP_OK,
+            ['success' => true],
+          ],
+
           'respondWithSuccess(), custom response data' => [
             'respondWithSuccess',
             [['order' => 237]],
@@ -93,6 +101,69 @@ class ResponseTest extends TestCase
             [new Collection(['invoice' => 23, 'status' => 'pending'])],
             Response::HTTP_OK,
             ['invoice' => 23, 'status' => 'pending'],
+          ],
+
+          'respondWithSuccess(), empty collection' => [
+            'respondWithSuccess',
+            [new Collection()],
+            Response::HTTP_OK,
+            ['success' => true],
+          ],
+
+          'respondWithSuccess(), Arrayable' => [
+            'respondWithSuccess',
+            [
+              new class implements Arrayable {
+                public function toArray()
+                {
+                  return ['id' => 1, 'name' => 'John'];
+                }
+              },
+            ],
+            Response::HTTP_OK,
+            ['id' => 1, 'name' => 'John']
+          ],
+
+          'respondWithSuccess(), empty Arrayable' => [
+            'respondWithSuccess',
+            [
+              new class implements Arrayable {
+                public function toArray()
+                {
+                  return [];
+                }
+              },
+            ],
+            Response::HTTP_OK,
+            ['success' => true]
+          ],
+
+          'respondWithSuccess(), JsonSerializable' => [
+            'respondWithSuccess',
+            [
+              new class implements \JsonSerializable {
+                public function jsonSerialize()
+                {
+                  return ['id' => 1, 'name' => 'John'];
+                }
+              },
+            ],
+            Response::HTTP_OK,
+            ['id' => 1, 'name' => 'John']
+          ],
+
+          'respondWithSuccess(), empty JsonSerializable' => [
+            'respondWithSuccess',
+            [
+              new class implements \JsonSerializable {
+                public function jsonSerialize()
+                {
+                  return [];
+                }
+              },
+            ],
+            Response::HTTP_OK,
+            ['success' => true]
           ],
 
           'respondOk()' => [

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -235,6 +235,13 @@ class ResponseTest extends TestCase
             [],
           ],
 
+          'respondCreated() with null' => [
+            'respondCreated',
+            [null],
+            Response::HTTP_CREATED,
+            [],
+          ],
+
           'respondCreated() with response data' => [
             'respondCreated',
             [['user' => ['name' => 'Jet Li']]],
@@ -313,6 +320,13 @@ class ResponseTest extends TestCase
           'respondNoContent()' => [
             'respondNoContent',
             [],
+            Response::HTTP_NO_CONTENT,
+            [],
+          ],
+
+          'respondNoContent() with null' => [
+            'respondNoContent',
+            [null],
             Response::HTTP_NO_CONTENT,
             [],
           ],

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace F9Web\ApiResponseHelpers\Tests;
 
-use F9Web\ApiResponseHelpers;
-use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Http\JsonResponse;
-use Symfony\Component\HttpFoundation\Response;
-use JsonException;
 use DomainException;
-use Illuminate\Support\Collection;
+use F9Web\ApiResponseHelpers;
 use F9Web\ApiResponseHelpers\Tests\Models\User;
 use F9Web\ApiResponseHelpers\Tests\Resources\UserResource;
-use Illuminate\Database\Eloquent\Collection As EloquentCollection;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Collection;
+use JsonException;
+use Symfony\Component\HttpFoundation\Response;
 
 use function json_encode;
 


### PR DESCRIPTION
1. Pulled out default success response data to a field
2. Added fluent method for setting default success response data
3. Added tests for usage of new method
4. Added missing tests for null values in respondWithSuccess, respondCreated, respondNoContent and fixed problems
    - null values were allowed both in types and phpdocs, yet exceptions were thrown when passed, this is fixed and null values are returned as empty arrays
5. Added missing tests for Arrayable, JsonSerializable and Collection and their empty variants
6. Strengthened tests to use strict assertions