### PR TITLE
create a respondWithErrors and setDefaultErrorsResponse for errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ Returns a `403` HTTP status code
 
 Returns a `400` HTTP status code
 
+#### `respondWithErrors(array|Arrayable|JsonSerializable|null $contents = null)`
+
+Returns a `400` HTTP status code
+
 #### `respondCreated(array|Arrayable|JsonSerializable|null $data = null)`
 
 Returns a `201` HTTP status code, with response optional data

--- a/src/ApiResponseHelpers.php
+++ b/src/ApiResponseHelpers.php
@@ -88,17 +88,8 @@ trait ApiResponseHelpers
     public function respondWithErrors($contents = null): JsonResponse
     {
         $contents = $this->morphToArray($contents) ?? [];
-
         $data = [] === $contents
-            ? $this->_api_helpers_defaultErrorData
-            : $contents;
-
-        return $this->apiResponse(
-            ['errors' => $data],
-            Response::HTTP_BAD_REQUEST
-        );
-        $data = [] === $contents
-        ? $this->_api_helpers_defaultSuccessData
+        ? $this->_api_helpers_defaultErrorData
         : $contents;
 
     return $this->apiResponse($data);

--- a/src/ApiResponseHelpers.php
+++ b/src/ApiResponseHelpers.php
@@ -15,6 +15,7 @@ use function response;
 trait ApiResponseHelpers
 {
     private ?array $_api_helpers_defaultSuccessData = ['success' => true];
+    private ?array $_api_helpers_defaultErrorData = ['success' => false];
 
     /**
      * @param string|\Exception $message
@@ -79,6 +80,34 @@ trait ApiResponseHelpers
             ['error' => $message ?? 'Error'],
             Response::HTTP_BAD_REQUEST
         );
+    }
+
+    /**
+     * @param array|Arrayable|JsonSerializable|null $contents
+    */
+    public function respondWithErrors($contents = null): JsonResponse
+    {
+        $contents = $this->morphToArray($contents) ?? [];
+
+        $data = [] === $contents
+            ? $this->_api_helpers_defaultErrorData
+            : $contents;
+
+        return $this->apiResponse(
+            ['errors' => $data],
+            Response::HTTP_BAD_REQUEST
+        );
+        $data = [] === $contents
+        ? $this->_api_helpers_defaultSuccessData
+        : $contents;
+
+    return $this->apiResponse($data);
+    }
+
+    public function setDefaultErrorsResponse(?array $content = null): self
+    {
+        $this->_api_helpers_defaultErrorData = $content ?? [];
+        return $this;
     }
 
     /**

--- a/src/ApiResponseHelpers.php
+++ b/src/ApiResponseHelpers.php
@@ -87,12 +87,14 @@ trait ApiResponseHelpers
     */
     public function respondWithErrors($contents = null): JsonResponse
     {
-        $contents = $this->morphToArray($contents) ?? [];
         $data = [] === $contents
-        ? $this->_api_helpers_defaultErrorData
-        : $contents;
+            ? $this->_api_helpers_defaultErrorData
+            : $contents;
 
-    return $this->apiResponse($data);
+        return $this->apiResponse(
+            ['errors' => $data],
+            Response::HTTP_BAD_REQUEST
+        );
     }
 
     public function setDefaultErrorsResponse(?array $content = null): self

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -62,7 +62,7 @@ class ResponseTest extends TestCase
     {
         $response = $this->service->setDefaultErrorsResponse($default)->respondWithErrors($args);
         self::assertInstanceOf(JsonResponse::class, $response);
-        self::assertSame(400, $response->getStatusCode());
+        self::assertSame($code, $response->getStatusCode());
         self::assertSame($data, $response->getData(true));
         self::assertJsonStringEqualsJsonString(json_encode($data, JSON_THROW_ON_ERROR), $response->getContent());
     }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -62,7 +62,7 @@ class ResponseTest extends TestCase
     {
         $response = $this->service->setDefaultErrorsResponse($default)->respondWithErrors($args);
         self::assertInstanceOf(JsonResponse::class, $response);
-        self::assertSame($code, $response->getStatusCode());
+        self::assertSame(400, $response->getStatusCode());
         self::assertSame($data, $response->getData(true));
         self::assertJsonStringEqualsJsonString(json_encode($data, JSON_THROW_ON_ERROR), $response->getContent());
     }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -54,6 +54,19 @@ class ResponseTest extends TestCase
         self::assertJsonStringEqualsJsonString(json_encode($data, JSON_THROW_ON_ERROR), $response->getContent());
     }
 
+    /**
+     * @dataProvider errorsDefaultsDataProvider
+     * @throws JsonException
+     */
+    public function testErrorsResponseDefaults(?array $default, $args, int $code, array $data): void
+    {
+        $response = $this->service->setDefaultErrorsResponse($default)->respondWithErrors($args);
+        self::assertInstanceOf(JsonResponse::class, $response);
+        self::assertSame($code, $response->getStatusCode());
+        self::assertSame($data, $response->getData(true));
+        self::assertJsonStringEqualsJsonString(json_encode($data, JSON_THROW_ON_ERROR), $response->getContent());
+    }
+
     public function basicResponsesDataProvider(): array
     {
         return [
@@ -350,6 +363,42 @@ class ResponseTest extends TestCase
     }
 
     public function successDefaultsDataProvider(): array
+    {
+        return [
+            'respondWithErrors(), default empty array' => [
+                'default' => [],
+                'args' => [],
+                'code' => Response::HTTP_OK,
+                'data' => [],
+            ],
+            'respondWithErrors(), default null' => [
+                'default' => null,
+                'args' => [],
+                'code' => Response::HTTP_OK,
+                'data' => [],
+            ],
+            'respondWithErrors(), default null, null response' => [
+                'default' => null,
+                'args' => null,
+                'code' => Response::HTTP_OK,
+                'data' => [],
+            ],
+            'respondWithErrors(), default non-empty array' => [
+                'default' => ['message' => 'Task successful!'],
+                'args' => [],
+                'code' => Response::HTTP_OK,
+                'data' => ['message' => 'Task successful!'],
+            ],
+            'respondWithErrors(), default non-empty array, custom response data' => [
+                'default' => ['message' => 'Task successful!'],
+                'args' => ['numbers' => [1, 2, 3]],
+                'code' => Response::HTTP_OK,
+                'data' => ['numbers' => [1, 2, 3]],
+            ]
+        ];
+    }
+
+    public function errorsDefaultsDataProvider(): array
     {
         return [
             'respondWithSuccess(), default empty array' => [


### PR DESCRIPTION
we need multi errors showing function in API response that why create a new respondWithErrors and setDefaultErrorsResponse for errors

@ultrono and @f9web 