### PR TITLE
Multiple code quality improvements

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,14 +27,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Get Composer cache directory
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: composer-cache-${{ runner.os }}-php-${{ matrix.php }}-L${{ matrix.laravel }}-${{ hashFiles('**/composer.lock') }}

--- a/src/ApiResponseHelpers.php
+++ b/src/ApiResponseHelpers.php
@@ -4,38 +4,38 @@ declare(strict_types=1);
 
 namespace F9Web;
 
-use Exception;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Http\JsonResponse;
 use JsonSerializable;
 use Symfony\Component\HttpFoundation\Response;
+use Throwable;
 
 use function response;
 
 trait ApiResponseHelpers
 {
     private ?array $_api_helpers_defaultSuccessData = [
-        'success' => true,
+      'success' => true,
     ];
 
     public function respondNotFound(
-        string|Exception $message,
-        ?string $key = 'error'
+      string|Throwable $message,
+      ?string $key = 'error'
     ): JsonResponse {
         return $this->apiResponse(
-            data: [$key => $this->morphMessage($message)],
-            code: Response::HTTP_NOT_FOUND
+          data: [$key => $this->morphMessage($message)],
+          code: Response::HTTP_NOT_FOUND
         );
     }
 
     public function respondWithSuccess(
-        array|Arrayable|JsonSerializable|null $contents = null
+      array|Arrayable|JsonSerializable|null $contents = null
     ): JsonResponse {
         $contents = $this->morphToArray(data: $contents) ?? [];
 
         $data = [] === $contents
-            ? $this->_api_helpers_defaultSuccessData
-            : $contents;
+          ? $this->_api_helpers_defaultSuccessData
+          : $contents;
 
         return $this->apiResponse(data: $data);
     }
@@ -43,6 +43,7 @@ trait ApiResponseHelpers
     public function setDefaultSuccessResponse(?array $content = null): self
     {
         $this->_api_helpers_defaultSuccessData = $content ?? [];
+
         return $this;
     }
 
@@ -54,45 +55,43 @@ trait ApiResponseHelpers
     public function respondUnAuthenticated(?string $message = null): JsonResponse
     {
         return $this->apiResponse(
-            data: ['error' => $message ?? 'Unauthenticated'],
-            code: Response::HTTP_UNAUTHORIZED
+          data: ['error' => $message ?? 'Unauthenticated'],
+          code: Response::HTTP_UNAUTHORIZED
         );
     }
 
     public function respondForbidden(?string $message = null): JsonResponse
     {
         return $this->apiResponse(
-            data: ['error' => $message ?? 'Forbidden'],
-            code: Response::HTTP_FORBIDDEN
+          data: ['error' => $message ?? 'Forbidden'],
+          code: Response::HTTP_FORBIDDEN
         );
     }
 
     public function respondError(?string $message = null): JsonResponse
     {
         return $this->apiResponse(
-            data: ['error' => $message ?? 'Error'],
-            code: Response::HTTP_BAD_REQUEST
+          data: ['error' => $message ?? 'Error'],
+          code: Response::HTTP_BAD_REQUEST
         );
     }
 
     public function respondCreated(
-        array|Arrayable|JsonSerializable|null $data = null
+      array|Arrayable|JsonSerializable|null $data = null
     ): JsonResponse {
-        $data ??= [];
-
         return $this->apiResponse(
-          data: $this->morphToArray(data: $data),
-            code: Response::HTTP_CREATED
+          data: $this->morphToArray(data: $data) ?? [],
+          code: Response::HTTP_CREATED
         );
     }
 
     public function respondFailedValidation(
-        string|Exception $message,
-        ?string $key = 'message'
+      string|Throwable $message,
+      ?string $key = 'message'
     ): JsonResponse {
         return $this->apiResponse(
-            data: [$key => $this->morphMessage($message)],
-            code: Response::HTTP_UNPROCESSABLE_ENTITY
+          data: [$key => $this->morphMessage($message)],
+          code: Response::HTTP_UNPROCESSABLE_ENTITY
         );
     }
 
@@ -100,23 +99,32 @@ trait ApiResponseHelpers
     {
         return $this->apiResponse(
           data: ['message' => 'I\'m a teapot'],
-            code: Response::HTTP_I_AM_A_TEAPOT
+          code: Response::HTTP_I_AM_A_TEAPOT
         );
     }
 
+    /**
+     * Per RFC 9110, a 204 response MUST NOT include content. Passing
+     * data to apiResponse() here violates the specification - any
+     * provided body is potentially ignored and can cause client
+     * errors. Functionality to return data here was added for legacy
+     * purposes only. In new projects call the method
+     * omitting any arguments
+     *
+     * @deprecated Will be removed in the next major release. The $data parameter
+     *             violates RFC 9110 — a 204 response MUST NOT include content.
+     *             Use respondNoContent() with no arguments.
+     */
     public function respondNoContent(
-        array|Arrayable|JsonSerializable|null $data = null
+      array|Arrayable|JsonSerializable|null $data = null
     ): JsonResponse {
-        $data ??= [];
-        $data = $this->morphToArray(data: $data);
-
         return $this->apiResponse(
-            data: $data,
-            code: Response::HTTP_NO_CONTENT
+          data: $this->morphToArray(data: $data) ?? [],
+          code: Response::HTTP_NO_CONTENT
         );
     }
 
-    private function apiResponse(array $data, int $code = 200): JsonResponse
+    private function apiResponse(array $data, int $code = Response::HTTP_OK): JsonResponse
     {
         return response()->json(data: $data, status: $code);
     }
@@ -128,15 +136,16 @@ trait ApiResponseHelpers
         }
 
         if ($data instanceof JsonSerializable) {
-            return $data->jsonSerialize();
+            $result = $data->jsonSerialize();
+            return is_array($result) ? $result : [$result];
         }
 
         return $data;
     }
 
-    private function morphMessage(string|Exception $message): string
+    private function morphMessage(string|Throwable $message): string
     {
-        return $message instanceof Exception
+        return $message instanceof Throwable
           ? $message->getMessage()
           : $message;
     }

--- a/src/ApiResponseHelpers.php
+++ b/src/ApiResponseHelpers.php
@@ -124,6 +124,31 @@ trait ApiResponseHelpers
         );
     }
 
+    public function respondAccepted(
+      array|Arrayable|JsonSerializable|null $data = null
+    ): JsonResponse {
+        return $this->apiResponse(
+          data: $this->morphToArray(data: $data) ?? [],
+          code: Response::HTTP_ACCEPTED
+        );
+    }
+
+    public function respondTooManyRequests(?string $message = null): JsonResponse
+    {
+        return $this->apiResponse(
+          data: ['error' => $message ?? 'Too Many Requests'],
+          code: Response::HTTP_TOO_MANY_REQUESTS
+        );
+    }
+
+    public function respondConflict(?string $message = null): JsonResponse
+    {
+        return $this->apiResponse(
+          data: ['error' => $message ?? 'Conflict'],
+          code: Response::HTTP_CONFLICT
+        );
+    }
+
     private function apiResponse(array $data, int $code = Response::HTTP_OK): JsonResponse
     {
         return response()->json(data: $data, status: $code);

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -12,13 +12,13 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Collection;
-use JsonException;
 use Symfony\Component\HttpFoundation\Response;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 use function json_encode;
 
-class ApiResponseService {
+class ApiResponseService 
+{
     use \F9Web\ApiResponseHelpers;
 }
 
@@ -33,7 +33,7 @@ class ResponseTest extends TestCase
     }
 
     /*
-     * @throws JsonException
+     * @throws \JsonException
      */
     #[DataProvider('basicResponsesDataProvider')]
     public function testResponses(string $method, array $args, int $code, array $data): void
@@ -47,10 +47,10 @@ class ResponseTest extends TestCase
     }
 
     /**
-     * @throws JsonException
+     * @throws \JsonException
      */
     #[DataProvider('successDefaultsDataProvider')]
-    public function testSuccessResponseDefaults(?array $default, $args, int $code, array $data): void
+    public function testSuccessResponseDefaults(?array $default, array|null $args, int $code, array $data): void
     {
         /** @var \Illuminate\Http\JsonResponse $response */
         $response = $this->service->setDefaultSuccessResponse($default)->respondWithSuccess($args);
@@ -60,315 +60,357 @@ class ResponseTest extends TestCase
         self::assertJsonStringEqualsJsonString(json_encode($data, JSON_THROW_ON_ERROR), $response->getContent());
     }
 
-    public static function basicResponsesDataProvider(): iterable
+        public static function basicResponsesDataProvider(): iterable
     {
-		yield 'respondNotFound()' => [
-			'respondNotFound',
-			['Ouch'],
-			Response::HTTP_NOT_FOUND,
-			['error' => 'Ouch'],
-		];
-		
-		yield 'respondNotFound() with custom key' => [
-			'respondNotFound',
-			['Ouch', 'message'],
-			Response::HTTP_NOT_FOUND,
-			['message' => 'Ouch'],
-		];
-		
-		yield 'respondNotFound() with exception and custom key' => [
-			'respondNotFound',
-			[new DomainException('Unknown model'), 'message'],
-			Response::HTTP_NOT_FOUND,
-			['message' => 'Unknown model'],
-		];
-		
-		yield 'respondWithSuccess(), default response data' => [
-			'respondWithSuccess',
-			[],
-			Response::HTTP_OK,
-			['success' => true],
-		];
-		
-		yield 'respondWithSuccess(), null response data' => [
-			'respondWithSuccess',
-			[null],
-			Response::HTTP_OK,
-			['success' => true],
-		];
-		
-		yield 'respondWithSuccess(), custom response data' => [
-			'respondWithSuccess',
-			[['order' => 237]],
-			Response::HTTP_OK,
-			['order' => 237],
-		];
-		
-		yield 'respondWithSuccess(), nested custom response data' => [
-			'respondWithSuccess',
-			[['order' => 237, 'customer' => ['name' => 'Jason Bourne']]],
-			Response::HTTP_OK,
-			['order' => 237, 'customer' => ['name' => 'Jason Bourne']],
-		];
-		
-		yield 'respondWithSuccess(), collection' => [
-			'respondWithSuccess',
-			[new Collection(['invoice' => 23, 'status' => 'pending'])],
-			Response::HTTP_OK,
-			['invoice' => 23, 'status' => 'pending'],
-		];
-		
-		yield 'respondWithSuccess(), empty collection' => [
-			'respondWithSuccess',
-			[new Collection()],
-			Response::HTTP_OK,
-			['success' => true],
-		];
-		
-		yield 'respondWithSuccess(), Arrayable' => [
-			'respondWithSuccess',
-			[
-				new class implements Arrayable {
-					public function toArray() { return ['id' => 1, 'name' => 'John']; }
-				},
-			],
-			Response::HTTP_OK,
-			['id' => 1, 'name' => 'John']
-		];
-		
-		yield 'respondWithSuccess(), empty Arrayable' => [
-			'respondWithSuccess',
-			[
-				new class implements Arrayable {
-					public function toArray() { return []; }
-				},
-			],
-			Response::HTTP_OK,
-			['success' => true]
-		];
-		
-		yield 'respondWithSuccess(), JsonSerializable' => [
-		'respondWithSuccess',
-			[
-				new class implements \JsonSerializable {
-					public function jsonSerialize() { return ['id' => 1, 'name' => 'John']; }
-				},
-			],
-			Response::HTTP_OK,
-			['id' => 1, 'name' => 'John']
-		];
-		
-		yield 'respondWithSuccess(), empty JsonSerializable' => [
-			'respondWithSuccess',
-			[
-				new class implements \JsonSerializable {
-					public function jsonSerialize() { return []; }
-				},
-			],
-			Response::HTTP_OK,
-			['success' => true]
-		];
-		
-		yield 'respondOk()' => [
-			'respondOk',
-			['Order accepted'],
-			Response::HTTP_OK,
-			['success' => 'Order accepted'],
-		];
-		
-		yield 'respondUnAuthenticated(), default message' => [
-			'respondUnAuthenticated',
-			[],
-			Response::HTTP_UNAUTHORIZED,
-			['error' => 'Unauthenticated'],
-		];
-		
-		yield 'respondUnAuthenticated(), custom message' => [
-			'respondUnAuthenticated',
-			['Denied'],
-			Response::HTTP_UNAUTHORIZED,
-			['error' => 'Denied'],
-		];
-		
-		yield 'respondForbidden(), default message' => [
-			'respondForbidden',
-			[],
-			Response::HTTP_FORBIDDEN,
-			['error' => 'Forbidden'],
-		];
-		
-		yield 'respondForbidden(), custom message' => [
-			'respondForbidden',
-			['Disavowed'],
-			Response::HTTP_FORBIDDEN,
-			['error' => 'Disavowed'],
-		];
-		
-		yield 'respondError(), default message' => [
-			'respondError',
-			[],
-			Response::HTTP_BAD_REQUEST,
-			['error' => 'Error'],
-		];
-		
-		yield 'respondError(), custom message' => [
-			'respondError',
-			['Order tampering detected'],
-			Response::HTTP_BAD_REQUEST,
-			['error' => 'Order tampering detected'],
-		];
-		
-		yield 'respondCreated()' => [
-			'respondCreated',
-			[],
-			Response::HTTP_CREATED,
-			[],
-		];
-		
-		yield 'respondCreated() with null' => [
-			'respondCreated',
-			[null],
-			Response::HTTP_CREATED,
-			[],
-		];
-		
-		yield 'respondCreated() with response data' => [
-			'respondCreated',
-			[['user' => ['name' => 'Jet Li']]],
-			Response::HTTP_CREATED,
-			['user' => ['name' => 'Jet Li']],
-		];
-		
-		yield 'respondCreated(), with collection as response' => [
-			'respondCreated',
-			[new Collection(['invoice' => 23, 'status' => 'pending'])],
-			Response::HTTP_CREATED,
-			['invoice' => 23, 'status' => 'pending'],
-		];
-		
-		yield 'respondCreated(), with eloquent collection as response' => [
-			'respondCreated',
-			[
-				new EloquentCollection([
-					new User(['name' => 'Jet Li', 'age' => 58]),
-					new User(['name' => 'Chow Yun-Fat', 'age' => 66]),
-					new User(['name' => 'Donnie Yen', 'age' => 58])
-				])
-			],
-			Response::HTTP_CREATED,
-			[
-				['name' => 'Jet Li', 'age' => 58],
-				['name' => 'Chow Yun-Fat', 'age' => 66],
-				['name' => 'Donnie Yen', 'age' => 58]
-			],
-		];
-		
-		yield 'respondCreated(), with json resource as response' => [
-			'respondCreated',
-			[
-				new UserResource(new User(['name' => 'Jet Li', 'age' => 58]))
-			],
-			Response::HTTP_CREATED,
-			['nameAndAge' => 'Jet Li & 58'],
-		];
-		
-		yield 'respondCreated(), with resource collection as response' => [
-			'respondCreated',
-			[
-				UserResource::collection(
-					new EloquentCollection([
-						new User(['name' => 'Jet Li', 'age' => 58]),
-						new User(['name' => 'Chow Yun-Fat', 'age' => 66]),
-						new User(['name' => 'Donnie Yen', 'age' => 58])
-					])
-				)
-			],
-			Response::HTTP_CREATED,
-			[
-				['nameAndAge' => 'Jet Li & 58'],
-				['nameAndAge' => 'Chow Yun-Fat & 66'],
-				['nameAndAge' => 'Donnie Yen & 58']
-			],
-		];
-		
-		yield 'respondFailedValidation()' => [
-			'respondFailedValidation',
-			['An invoice is required'],
-			Response::HTTP_UNPROCESSABLE_ENTITY,
-			['message' => 'An invoice is required'],
-		];
-		
-		yield 'respondTeapot()' => [
-			'respondTeapot',
-			[],
-			Response::HTTP_I_AM_A_TEAPOT,
-			['message' => 'I\'m a teapot'],
-		];
-		
-		yield 'respondNoContent()' => [
-			'respondNoContent',
-			[],
-			Response::HTTP_NO_CONTENT,
-			[],
-		];
-		
-		yield 'respondNoContent() with null' => [
-			'respondNoContent',
-			[null],
-			Response::HTTP_NO_CONTENT,
-			[],
-		];
-		
-		// @see https://github.com/f9webltd/laravel-api-response-helpers/issues/5#issuecomment-917418285
-		yield 'respondNoContent() with data' => [
-			'respondNoContent',
-			[['role' => 'manager']],
-			Response::HTTP_NO_CONTENT,
-			['role' => 'manager'],
-		];
-		
-		// @see https://github.com/f9webltd/laravel-api-response-helpers/issues/5#issuecomment-917418285
-		yield 'respondNoContent(), with collection as response' => [
-			'respondNoContent',
-			[new Collection(['invoice' => 23, 'status' => 'pending'])],
-			Response::HTTP_NO_CONTENT,
-			['invoice' => 23, 'status' => 'pending'],
-		];
+        yield 'respondNotFound()' => [
+          'respondNotFound',
+          ['Ouch'],
+          Response::HTTP_NOT_FOUND,
+          ['error' => 'Ouch'],
+        ];
 
-		yield 'respondAccepted() with data' => [
-			'respondAccepted',
-			[['role' => 'manager']],
-			Response::HTTP_ACCEPTED,
-			['role' => 'manager'],
-		];
+        yield 'respondNotFound() with custom key' => [
+          'respondNotFound',
+          ['Ouch', 'message'],
+          Response::HTTP_NOT_FOUND,
+          ['message' => 'Ouch'],
+        ];
 
-		yield 'respondConflict(), no message' => [
-			'respondConflict',
-			[null],
-			Response::HTTP_CONFLICT,
-			['error' => 'Conflict'],
-		];
+        yield 'respondNotFound() with exception and custom key' => [
+          'respondNotFound',
+          [new DomainException('Unknown model'), 'message'],
+          Response::HTTP_NOT_FOUND,
+          ['message' => 'Unknown model'],
+        ];
 
-		yield 'respondConflict(), custom message' => [
-			'respondConflict',
-			['Hmmm, conflicted ...'],
-			Response::HTTP_CONFLICT,
-			['error' => 'Hmmm, conflicted ...'],
-		];
+        yield 'respondNotFound() with Error' => [
+          'respondNotFound',
+          [new \TypeError('Type mismatch')],
+          Response::HTTP_NOT_FOUND,
+          ['error' => 'Type mismatch'],
+        ];
 
-		yield 'respondTooManyRequests(), no message' => [
-			'respondTooManyRequests',
-			[null],
-			Response::HTTP_TOO_MANY_REQUESTS,
-			['error' => 'Too Many Requests'],
-		];
+        yield 'respondWithSuccess(), default response data' => [
+          'respondWithSuccess',
+          [],
+          Response::HTTP_OK,
+          ['success' => true],
+        ];
 
-		yield 'respondTooManyRequests(), custom message' => [
-			'respondTooManyRequests',
-			['Spamming ...'],
-			Response::HTTP_TOO_MANY_REQUESTS,
-			['error' => 'Spamming ...'],
-		];
+        yield 'respondWithSuccess(), null response data' => [
+          'respondWithSuccess',
+          [null],
+          Response::HTTP_OK,
+          ['success' => true],
+        ];
+
+        yield 'respondWithSuccess(), custom response data' => [
+          'respondWithSuccess',
+          [['order' => 237]],
+          Response::HTTP_OK,
+          ['order' => 237],
+        ];
+
+        yield 'respondWithSuccess(), nested custom response data' => [
+          'respondWithSuccess',
+          [['order' => 237, 'customer' => ['name' => 'Jason Bourne']]],
+          Response::HTTP_OK,
+          ['order' => 237, 'customer' => ['name' => 'Jason Bourne']],
+        ];
+
+        yield 'respondWithSuccess(), collection' => [
+          'respondWithSuccess',
+          [new Collection(['invoice' => 23, 'status' => 'pending'])],
+          Response::HTTP_OK,
+          ['invoice' => 23, 'status' => 'pending'],
+        ];
+
+        yield 'respondWithSuccess(), empty collection' => [
+          'respondWithSuccess',
+          [new Collection()],
+          Response::HTTP_OK,
+          ['success' => true],
+        ];
+
+        yield 'respondWithSuccess(), Arrayable' => [
+          'respondWithSuccess',
+          [
+            new class implements Arrayable {
+                public function toArray() { return ['id' => 1, 'name' => 'John']; }
+            },
+          ],
+          Response::HTTP_OK,
+          ['id' => 1, 'name' => 'John']
+        ];
+
+        yield 'respondWithSuccess(), empty Arrayable' => [
+          'respondWithSuccess',
+          [
+            new class implements Arrayable {
+                public function toArray() { return []; }
+            },
+          ],
+          Response::HTTP_OK,
+          ['success' => true]
+        ];
+
+        yield 'respondWithSuccess(), JsonSerializable' => [
+          'respondWithSuccess',
+          [
+            new class implements \JsonSerializable {
+                public function jsonSerialize() { return ['id' => 1, 'name' => 'John']; }
+            },
+          ],
+          Response::HTTP_OK,
+          ['id' => 1, 'name' => 'John']
+        ];
+
+        yield 'respondWithSuccess(), empty JsonSerializable' => [
+          'respondWithSuccess',
+          [
+            new class implements \JsonSerializable {
+                public function jsonSerialize() { return []; }
+            },
+          ],
+          Response::HTTP_OK,
+          ['success' => true]
+        ];
+
+        yield 'respondOk()' => [
+          'respondOk',
+          ['Order accepted'],
+          Response::HTTP_OK,
+          ['success' => 'Order accepted'],
+        ];
+
+        yield 'respondUnAuthenticated(), default message' => [
+          'respondUnAuthenticated',
+          [],
+          Response::HTTP_UNAUTHORIZED,
+          ['error' => 'Unauthenticated'],
+        ];
+
+        yield 'respondUnAuthenticated(), custom message' => [
+          'respondUnAuthenticated',
+          ['Denied'],
+          Response::HTTP_UNAUTHORIZED,
+          ['error' => 'Denied'],
+        ];
+
+        yield 'respondForbidden(), default message' => [
+          'respondForbidden',
+          [],
+          Response::HTTP_FORBIDDEN,
+          ['error' => 'Forbidden'],
+        ];
+
+        yield 'respondForbidden(), custom message' => [
+          'respondForbidden',
+          ['Disavowed'],
+          Response::HTTP_FORBIDDEN,
+          ['error' => 'Disavowed'],
+        ];
+
+        yield 'respondError(), default message' => [
+          'respondError',
+          [],
+          Response::HTTP_BAD_REQUEST,
+          ['error' => 'Error'],
+        ];
+
+        yield 'respondError(), custom message' => [
+          'respondError',
+          ['Order tampering detected'],
+          Response::HTTP_BAD_REQUEST,
+          ['error' => 'Order tampering detected'],
+        ];
+
+        yield 'respondCreated()' => [
+          'respondCreated',
+          [],
+          Response::HTTP_CREATED,
+          [],
+        ];
+
+        yield 'respondCreated() with null' => [
+          'respondCreated',
+          [null],
+          Response::HTTP_CREATED,
+          [],
+        ];
+
+        yield 'respondCreated() with response data' => [
+          'respondCreated',
+          [['user' => ['name' => 'Jet Li']]],
+          Response::HTTP_CREATED,
+          ['user' => ['name' => 'Jet Li']],
+        ];
+
+        yield 'respondCreated(), with collection as response' => [
+          'respondCreated',
+          [new Collection(['invoice' => 23, 'status' => 'pending'])],
+          Response::HTTP_CREATED,
+          ['invoice' => 23, 'status' => 'pending'],
+        ];
+
+        yield 'respondCreated(), with eloquent collection as response' => [
+          'respondCreated',
+          [
+            new EloquentCollection([
+              new User(['name' => 'Jet Li', 'age' => 58]),
+              new User(['name' => 'Chow Yun-Fat', 'age' => 66]),
+              new User(['name' => 'Donnie Yen', 'age' => 58])
+            ])
+          ],
+          Response::HTTP_CREATED,
+          [
+            ['name' => 'Jet Li', 'age' => 58],
+            ['name' => 'Chow Yun-Fat', 'age' => 66],
+            ['name' => 'Donnie Yen', 'age' => 58]
+          ],
+        ];
+
+        yield 'respondCreated(), with json resource as response' => [
+          'respondCreated',
+          [
+            new UserResource(new User(['name' => 'Jet Li', 'age' => 58]))
+          ],
+          Response::HTTP_CREATED,
+          ['nameAndAge' => 'Jet Li & 58'],
+        ];
+
+        yield 'respondCreated(), with resource collection as response' => [
+          'respondCreated',
+          [
+            UserResource::collection(
+              new EloquentCollection([
+                new User(['name' => 'Jet Li', 'age' => 58]),
+                new User(['name' => 'Chow Yun-Fat', 'age' => 66]),
+                new User(['name' => 'Donnie Yen', 'age' => 58])
+              ])
+            )
+          ],
+          Response::HTTP_CREATED,
+          [
+            ['nameAndAge' => 'Jet Li & 58'],
+            ['nameAndAge' => 'Chow Yun-Fat & 66'],
+            ['nameAndAge' => 'Donnie Yen & 58']
+          ],
+        ];
+
+        yield 'respondFailedValidation()' => [
+          'respondFailedValidation',
+          ['An invoice is required'],
+          Response::HTTP_UNPROCESSABLE_ENTITY,
+          ['message' => 'An invoice is required'],
+        ];
+
+        yield 'respondFailedValidation() with exception' => [
+          'respondFailedValidation',
+          [new DomainException('Invoice required')],
+          Response::HTTP_UNPROCESSABLE_ENTITY,
+          ['message' => 'Invoice required'],
+        ];
+
+        yield 'respondFailedValidation() with custom key' => [
+          'respondFailedValidation',
+          ['Invoice required', 'error'],
+          Response::HTTP_UNPROCESSABLE_ENTITY,
+          ['error' => 'Invoice required'],
+        ];
+		
+        yield 'respondTeapot()' => [
+          'respondTeapot',
+          [],
+          Response::HTTP_I_AM_A_TEAPOT,
+          ['message' => 'I\'m a teapot'],
+        ];
+        
+        yield 'respondNoContent()' => [
+          'respondNoContent',
+          [],
+          Response::HTTP_NO_CONTENT,
+          [],
+        ];
+        
+        yield 'respondNoContent() with null' => [
+          'respondNoContent',
+          [null],
+          Response::HTTP_NO_CONTENT,
+          [],
+        ];
+        
+        // @see https://github.com/f9webltd/laravel-api-response-helpers/issues/5#issuecomment-917418285
+        yield 'respondNoContent() with data' => [
+          'respondNoContent',
+          [['role' => 'manager']],
+          Response::HTTP_NO_CONTENT,
+          ['role' => 'manager'],
+        ];
+        
+        // @see https://github.com/f9webltd/laravel-api-response-helpers/issues/5#issuecomment-917418285
+        yield 'respondNoContent(), with collection as response' => [
+          'respondNoContent',
+          [new Collection(['invoice' => 23, 'status' => 'pending'])],
+          Response::HTTP_NO_CONTENT,
+          ['invoice' => 23, 'status' => 'pending'],
+        ];
+    
+        yield 'respondAccepted() with data' => [
+          'respondAccepted',
+          [['role' => 'manager']],
+          Response::HTTP_ACCEPTED,
+          ['role' => 'manager'],
+        ];
+
+        yield 'respondAccepted(), no data' => [
+          'respondAccepted',
+          [],
+          Response::HTTP_ACCEPTED,
+          [],
+        ];
+        
+        yield 'respondAccepted() with null' => [
+          'respondAccepted',
+          [null],
+          Response::HTTP_ACCEPTED,
+          [],
+        ];
+
+        yield 'respondConflict(), no args' => [
+          'respondConflict',
+          [],
+          Response::HTTP_CONFLICT,
+          ['error' => 'Conflict'],
+        ];
+
+        yield 'respondConflict(), no message' => [
+          'respondConflict',
+          [null],
+          Response::HTTP_CONFLICT,
+          ['error' => 'Conflict'],
+        ];
+    
+        yield 'respondConflict(), custom message' => [
+          'respondConflict',
+          ['Hmmm, conflicted ...'],
+          Response::HTTP_CONFLICT,
+          ['error' => 'Hmmm, conflicted ...'],
+        ];
+    
+        yield 'respondTooManyRequests(), no message' => [
+          'respondTooManyRequests',
+          [null],
+          Response::HTTP_TOO_MANY_REQUESTS,
+          ['error' => 'Too Many Requests'],
+        ];
+    
+        yield 'respondTooManyRequests(), custom message' => [
+          'respondTooManyRequests',
+          ['Spamming ...'],
+          Response::HTTP_TOO_MANY_REQUESTS,
+          ['error' => 'Spamming ...'],
+        ];
     }
 
     public static function successDefaultsDataProvider(): iterable

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -123,7 +123,7 @@ class ResponseTest extends TestCase
 			[new Collection()],
 			Response::HTTP_OK,
 			['success' => true],
-		],
+		];
 		
 		yield 'respondWithSuccess(), Arrayable' => [
 			'respondWithSuccess',

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -60,334 +60,352 @@ class ResponseTest extends TestCase
         self::assertJsonStringEqualsJsonString(json_encode($data, JSON_THROW_ON_ERROR), $response->getContent());
     }
 
-    public static function basicResponsesDataProvider(): array
+    public static function basicResponsesDataProvider(): iterable
     {
-        return [
-          'respondNotFound()' => [
-            'respondNotFound',
-            ['Ouch'],
-            Response::HTTP_NOT_FOUND,
-            ['error' => 'Ouch'],
-          ],
+		yield 'respondNotFound()' => [
+			'respondNotFound',
+			['Ouch'],
+			Response::HTTP_NOT_FOUND,
+			['error' => 'Ouch'],
+		];
+		
+		yield 'respondNotFound() with custom key' => [
+			'respondNotFound',
+			['Ouch', 'message'],
+			Response::HTTP_NOT_FOUND,
+			['message' => 'Ouch'],
+		];
+		
+		yield 'respondNotFound() with exception and custom key' => [
+			'respondNotFound',
+			[new DomainException('Unknown model'), 'message'],
+			Response::HTTP_NOT_FOUND,
+			['message' => 'Unknown model'],
+		];
+		
+		yield 'respondWithSuccess(), default response data' => [
+			'respondWithSuccess',
+			[],
+			Response::HTTP_OK,
+			['success' => true],
+		];
+		
+		yield 'respondWithSuccess(), null response data' => [
+			'respondWithSuccess',
+			[null],
+			Response::HTTP_OK,
+			['success' => true],
+		];
+		
+		yield 'respondWithSuccess(), custom response data' => [
+			'respondWithSuccess',
+			[['order' => 237]],
+			Response::HTTP_OK,
+			['order' => 237],
+		];
+		
+		yield 'respondWithSuccess(), nested custom response data' => [
+			'respondWithSuccess',
+			[['order' => 237, 'customer' => ['name' => 'Jason Bourne']]],
+			Response::HTTP_OK,
+			['order' => 237, 'customer' => ['name' => 'Jason Bourne']],
+		];
+		
+		yield 'respondWithSuccess(), collection' => [
+			'respondWithSuccess',
+			[new Collection(['invoice' => 23, 'status' => 'pending'])],
+			Response::HTTP_OK,
+			['invoice' => 23, 'status' => 'pending'],
+		];
+		
+		yield 'respondWithSuccess(), empty collection' => [
+			'respondWithSuccess',
+			[new Collection()],
+			Response::HTTP_OK,
+			['success' => true],
+		],
+		
+		yield 'respondWithSuccess(), Arrayable' => [
+			'respondWithSuccess',
+			[
+				new class implements Arrayable {
+					public function toArray() { return ['id' => 1, 'name' => 'John']; }
+				},
+			],
+			Response::HTTP_OK,
+			['id' => 1, 'name' => 'John']
+		];
+		
+		yield 'respondWithSuccess(), empty Arrayable' => [
+			'respondWithSuccess',
+			[
+				new class implements Arrayable {
+					public function toArray() { return []; }
+				},
+			],
+			Response::HTTP_OK,
+			['success' => true]
+		];
+		
+		yield 'respondWithSuccess(), JsonSerializable' => [
+		'respondWithSuccess',
+			[
+				new class implements \JsonSerializable {
+					public function jsonSerialize() { return ['id' => 1, 'name' => 'John']; }
+				},
+			],
+			Response::HTTP_OK,
+			['id' => 1, 'name' => 'John']
+		];
+		
+		yield 'respondWithSuccess(), empty JsonSerializable' => [
+			'respondWithSuccess',
+			[
+				new class implements \JsonSerializable {
+					public function jsonSerialize() { return []; }
+				},
+			],
+			Response::HTTP_OK,
+			['success' => true]
+		];
+		
+		yield 'respondOk()' => [
+			'respondOk',
+			['Order accepted'],
+			Response::HTTP_OK,
+			['success' => 'Order accepted'],
+		];
+		
+		yield 'respondUnAuthenticated(), default message' => [
+			'respondUnAuthenticated',
+			[],
+			Response::HTTP_UNAUTHORIZED,
+			['error' => 'Unauthenticated'],
+		];
+		
+		yield 'respondUnAuthenticated(), custom message' => [
+			'respondUnAuthenticated',
+			['Denied'],
+			Response::HTTP_UNAUTHORIZED,
+			['error' => 'Denied'],
+		];
+		
+		yield 'respondForbidden(), default message' => [
+			'respondForbidden',
+			[],
+			Response::HTTP_FORBIDDEN,
+			['error' => 'Forbidden'],
+		];
+		
+		yield 'respondForbidden(), custom message' => [
+			'respondForbidden',
+			['Disavowed'],
+			Response::HTTP_FORBIDDEN,
+			['error' => 'Disavowed'],
+		];
+		
+		yield 'respondError(), default message' => [
+			'respondError',
+			[],
+			Response::HTTP_BAD_REQUEST,
+			['error' => 'Error'],
+		];
+		
+		yield 'respondError(), custom message' => [
+			'respondError',
+			['Order tampering detected'],
+			Response::HTTP_BAD_REQUEST,
+			['error' => 'Order tampering detected'],
+		];
+		
+		yield 'respondCreated()' => [
+			'respondCreated',
+			[],
+			Response::HTTP_CREATED,
+			[],
+		];
+		
+		yield 'respondCreated() with null' => [
+			'respondCreated',
+			[null],
+			Response::HTTP_CREATED,
+			[],
+		];
+		
+		yield 'respondCreated() with response data' => [
+			'respondCreated',
+			[['user' => ['name' => 'Jet Li']]],
+			Response::HTTP_CREATED,
+			['user' => ['name' => 'Jet Li']],
+		];
+		
+		yield 'respondCreated(), with collection as response' => [
+			'respondCreated',
+			[new Collection(['invoice' => 23, 'status' => 'pending'])],
+			Response::HTTP_CREATED,
+			['invoice' => 23, 'status' => 'pending'],
+		];
+		
+		yield 'respondCreated(), with eloquent collection as response' => [
+			'respondCreated',
+			[
+				new EloquentCollection([
+					new User(['name' => 'Jet Li', 'age' => 58]),
+					new User(['name' => 'Chow Yun-Fat', 'age' => 66]),
+					new User(['name' => 'Donnie Yen', 'age' => 58])
+				])
+			],
+			Response::HTTP_CREATED,
+			[
+				['name' => 'Jet Li', 'age' => 58],
+				['name' => 'Chow Yun-Fat', 'age' => 66],
+				['name' => 'Donnie Yen', 'age' => 58]
+			],
+		];
+		
+		yield 'respondCreated(), with json resource as response' => [
+			'respondCreated',
+			[
+				new UserResource(new User(['name' => 'Jet Li', 'age' => 58]))
+			],
+			Response::HTTP_CREATED,
+			['nameAndAge' => 'Jet Li & 58'],
+		];
+		
+		yield 'respondCreated(), with resource collection as response' => [
+			'respondCreated',
+			[
+				UserResource::collection(
+					new EloquentCollection([
+						new User(['name' => 'Jet Li', 'age' => 58]),
+						new User(['name' => 'Chow Yun-Fat', 'age' => 66]),
+						new User(['name' => 'Donnie Yen', 'age' => 58])
+					])
+				)
+			],
+			Response::HTTP_CREATED,
+			[
+				['nameAndAge' => 'Jet Li & 58'],
+				['nameAndAge' => 'Chow Yun-Fat & 66'],
+				['nameAndAge' => 'Donnie Yen & 58']
+			],
+		];
+		
+		yield 'respondFailedValidation()' => [
+			'respondFailedValidation',
+			['An invoice is required'],
+			Response::HTTP_UNPROCESSABLE_ENTITY,
+			['message' => 'An invoice is required'],
+		];
+		
+		yield 'respondTeapot()' => [
+			'respondTeapot',
+			[],
+			Response::HTTP_I_AM_A_TEAPOT,
+			['message' => 'I\'m a teapot'],
+		];
+		
+		yield 'respondNoContent()' => [
+			'respondNoContent',
+			[],
+			Response::HTTP_NO_CONTENT,
+			[],
+		];
+		
+		yield 'respondNoContent() with null' => [
+			'respondNoContent',
+			[null],
+			Response::HTTP_NO_CONTENT,
+			[],
+		];
+		
+		// @see https://github.com/f9webltd/laravel-api-response-helpers/issues/5#issuecomment-917418285
+		yield 'respondNoContent() with data' => [
+			'respondNoContent',
+			[['role' => 'manager']],
+			Response::HTTP_NO_CONTENT,
+			['role' => 'manager'],
+		];
+		
+		// @see https://github.com/f9webltd/laravel-api-response-helpers/issues/5#issuecomment-917418285
+		yield 'respondNoContent(), with collection as response' => [
+			'respondNoContent',
+			[new Collection(['invoice' => 23, 'status' => 'pending'])],
+			Response::HTTP_NO_CONTENT,
+			['invoice' => 23, 'status' => 'pending'],
+		];
 
-          'respondNotFound() with custom key' => [
-            'respondNotFound',
-            ['Ouch', 'message'],
-            Response::HTTP_NOT_FOUND,
-            ['message' => 'Ouch'],
-          ],
+		yield 'respondAccepted() with data' => [
+			'respondAccepted',
+			[['role' => 'manager']],
+			Response::HTTP_ACCEPTED,
+			[],
+		];
 
-          'respondNotFound() with exception and custom key' => [
-            'respondNotFound',
-            [
-              new DomainException('Unknown model'),
-              'message'
-            ],
-            Response::HTTP_NOT_FOUND,
-            ['message' => 'Unknown model'],
-          ],
+		yield 'respondConflict(), no message' => [
+			'respondConflict',
+			[null],
+			Response::HTTP_CONFLICT,
+			['error' => 'Conflict'],
+		];
 
-          'respondWithSuccess(), default response data' => [
-            'respondWithSuccess',
-            [],
-            Response::HTTP_OK,
-            ['success' => true],
-          ],
+		yield 'respondConflict(), custom message' => [
+			'respondConflict',
+			['Hmmm, conflicted ...'],
+			Response::HTTP_CONFLICT,
+			['error' => 'Hmmm, conflicted ...'],
+		];
 
-          'respondWithSuccess(), null response data' => [
-            'respondWithSuccess',
-            [null],
-            Response::HTTP_OK,
-            ['success' => true],
-          ],
+		yield 'respondTooManyRequests(), no message' => [
+			'respondTooManyRequests',
+			[null],
+			Response::HTTP_TOO_MANY_REQUESTS,
+			['error' => 'Too Many Requests'],
+		];
 
-          'respondWithSuccess(), custom response data' => [
-            'respondWithSuccess',
-            [['order' => 237]],
-            Response::HTTP_OK,
-            ['order' => 237],
-          ],
-
-          'respondWithSuccess(), nested custom response data' => [
-            'respondWithSuccess',
-            [['order' => 237, 'customer' => ['name' => 'Jason Bourne']]],
-            Response::HTTP_OK,
-            ['order' => 237, 'customer' => ['name' => 'Jason Bourne']],
-          ],
-
-          'respondWithSuccess(), collection' => [
-            'respondWithSuccess',
-            [new Collection(['invoice' => 23, 'status' => 'pending'])],
-            Response::HTTP_OK,
-            ['invoice' => 23, 'status' => 'pending'],
-          ],
-
-          'respondWithSuccess(), empty collection' => [
-            'respondWithSuccess',
-            [new Collection()],
-            Response::HTTP_OK,
-            ['success' => true],
-          ],
-
-          'respondWithSuccess(), Arrayable' => [
-            'respondWithSuccess',
-            [
-              new class implements Arrayable {
-                public function toArray()
-                {
-                  return ['id' => 1, 'name' => 'John'];
-                }
-              },
-            ],
-            Response::HTTP_OK,
-            ['id' => 1, 'name' => 'John']
-          ],
-
-          'respondWithSuccess(), empty Arrayable' => [
-            'respondWithSuccess',
-            [
-              new class implements Arrayable {
-                public function toArray()
-                {
-                  return [];
-                }
-              },
-            ],
-            Response::HTTP_OK,
-            ['success' => true]
-          ],
-
-          'respondWithSuccess(), JsonSerializable' => [
-            'respondWithSuccess',
-            [
-              new class implements \JsonSerializable {
-                public function jsonSerialize()
-                {
-                  return ['id' => 1, 'name' => 'John'];
-                }
-              },
-            ],
-            Response::HTTP_OK,
-            ['id' => 1, 'name' => 'John']
-          ],
-
-          'respondWithSuccess(), empty JsonSerializable' => [
-            'respondWithSuccess',
-            [
-              new class implements \JsonSerializable {
-                public function jsonSerialize()
-                {
-                  return [];
-                }
-              },
-            ],
-            Response::HTTP_OK,
-            ['success' => true]
-          ],
-
-          'respondOk()' => [
-            'respondOk',
-            ['Order accepted'],
-            Response::HTTP_OK,
-            ['success' => 'Order accepted'],
-          ],
-
-          'respondUnAuthenticated(), default message' => [
-            'respondUnAuthenticated',
-            [],
-            Response::HTTP_UNAUTHORIZED,
-            ['error' => 'Unauthenticated'],
-          ],
-
-          'respondUnAuthenticated(), custom message' => [
-            'respondUnAuthenticated',
-            ['Denied'],
-            Response::HTTP_UNAUTHORIZED,
-            ['error' => 'Denied'],
-          ],
-
-          'respondForbidden(), default message' => [
-            'respondForbidden',
-            [],
-            Response::HTTP_FORBIDDEN,
-            ['error' => 'Forbidden'],
-          ],
-
-          'respondForbidden(), custom message' => [
-            'respondForbidden',
-            ['Disavowed'],
-            Response::HTTP_FORBIDDEN,
-            ['error' => 'Disavowed'],
-          ],
-
-          'respondError(), default message' => [
-            'respondError',
-            [],
-            Response::HTTP_BAD_REQUEST,
-            ['error' => 'Error'],
-          ],
-
-          'respondError(), custom message' => [
-            'respondError',
-            ['Order tampering detected'],
-            Response::HTTP_BAD_REQUEST,
-            ['error' => 'Order tampering detected'],
-          ],
-
-          'respondCreated()' => [
-            'respondCreated',
-            [],
-            Response::HTTP_CREATED,
-            [],
-          ],
-
-          'respondCreated() with null' => [
-            'respondCreated',
-            [null],
-            Response::HTTP_CREATED,
-            [],
-          ],
-
-          'respondCreated() with response data' => [
-            'respondCreated',
-            [['user' => ['name' => 'Jet Li']]],
-            Response::HTTP_CREATED,
-            ['user' => ['name' => 'Jet Li']],
-          ],
-
-          'respondCreated(), with collection as response' => [
-            'respondCreated',
-            [new Collection(['invoice' => 23, 'status' => 'pending'])],
-            Response::HTTP_CREATED,
-            ['invoice' => 23, 'status' => 'pending'],
-          ],
-
-          'respondCreated(), with eloquent collection as response' => [
-            'respondCreated',
-            [
-              new EloquentCollection([
-                new User(['name' => 'Jet Li', 'age' => 58]),
-                new User(['name' => 'Chow Yun-Fat', 'age' => 66]),
-                new User(['name' => 'Donnie Yen', 'age' => 58])
-              ])
-            ],
-            Response::HTTP_CREATED,
-            [
-              ['name' => 'Jet Li', 'age' => 58],
-              ['name' => 'Chow Yun-Fat', 'age' => 66],
-              ['name' => 'Donnie Yen', 'age' => 58]
-            ],
-          ],
-
-          'respondCreated(), with json resource as response' => [
-            'respondCreated',
-            [
-              new UserResource(
-                new User(['name' => 'Jet Li', 'age' => 58])
-              )
-            ],
-            Response::HTTP_CREATED,
-            ['nameAndAge' => 'Jet Li & 58'],
-          ],
-
-          'respondCreated(), with resource collection as response' => [
-            'respondCreated',
-            [
-              UserResource::collection(
-                new EloquentCollection([
-                  new User(['name' => 'Jet Li', 'age' => 58]),
-                  new User(['name' => 'Chow Yun-Fat', 'age' => 66]),
-                  new User(['name' => 'Donnie Yen', 'age' => 58])
-                ])
-              )
-            ],
-            Response::HTTP_CREATED,
-            [
-              ['nameAndAge' => 'Jet Li & 58'],
-              ['nameAndAge' => 'Chow Yun-Fat & 66'],
-              ['nameAndAge' => 'Donnie Yen & 58']
-            ],
-          ],
-
-          'respondFailedValidation()' => [
-            'respondFailedValidation',
-            ['An invoice is required'],
-            Response::HTTP_UNPROCESSABLE_ENTITY,
-            ['message' => 'An invoice is required'],
-          ],
-
-          'respondTeapot()' => [
-            'respondTeapot',
-            [],
-            Response::HTTP_I_AM_A_TEAPOT,
-            ['message' => 'I\'m a teapot'],
-          ],
-
-          'respondNoContent()' => [
-            'respondNoContent',
-            [],
-            Response::HTTP_NO_CONTENT,
-            [],
-          ],
-
-          'respondNoContent() with null' => [
-            'respondNoContent',
-            [null],
-            Response::HTTP_NO_CONTENT,
-            [],
-          ],
-
-          // @see https://github.com/f9webltd/laravel-api-response-helpers/issues/5#issuecomment-917418285
-          'respondNoContent() with data' => [
-            'respondNoContent',
-            [['role' => 'manager']],
-            Response::HTTP_NO_CONTENT,
-            ['role' => 'manager'],
-          ],
-
-          // @see https://github.com/f9webltd/laravel-api-response-helpers/issues/5#issuecomment-917418285
-          'respondNoContent(), with collection as response' => [
-            'respondNoContent',
-            [new Collection(['invoice' => 23, 'status' => 'pending'])],
-            Response::HTTP_NO_CONTENT,
-            ['invoice' => 23, 'status' => 'pending'],
-          ],
-        ];
+		yield 'respondTooManyRequests(), custom message' => [
+			'respondTooManyRequests',
+			['Spamming ...'],
+			Response::HTTP_TOO_MANY_REQUESTS,
+			['error' => 'Spamming ...'],
+		];
     }
 
-    public static function successDefaultsDataProvider(): array
+    public static function successDefaultsDataProvider(): iterable
     {
-        return [
-            'respondWithSuccess(), default empty array' => [
-                'default' => [],
-                'args' => [],
-                'code' => Response::HTTP_OK,
-                'data' => [],
-            ],
-            'respondWithSuccess(), default null' => [
-                'default' => null,
-                'args' => [],
-                'code' => Response::HTTP_OK,
-                'data' => [],
-            ],
-            'respondWithSuccess(), default null, null response' => [
-                'default' => null,
-                'args' => null,
-                'code' => Response::HTTP_OK,
-                'data' => [],
-            ],
-            'respondWithSuccess(), default non-empty array' => [
-                'default' => ['message' => 'Task successful!'],
-                'args' => [],
-                'code' => Response::HTTP_OK,
-                'data' => ['message' => 'Task successful!'],
-            ],
-            'respondWithSuccess(), default non-empty array, custom response data' => [
-                'default' => ['message' => 'Task successful!'],
-                'args' => ['numbers' => [1, 2, 3]],
-                'code' => Response::HTTP_OK,
-                'data' => ['numbers' => [1, 2, 3]],
-            ]
+        yield 'respondWithSuccess(), default empty array' => [
+            'default' => [],
+            'args' => [],
+            'code' => Response::HTTP_OK,
+            'data' => [],
+        ];
+
+        yield 'respondWithSuccess(), default null' => [
+            'default' => null,
+            'args' => [],
+            'code' => Response::HTTP_OK,
+            'data' => [],
+        ];
+
+        yield 'respondWithSuccess(), default null, null response' => [
+            'default' => null,
+            'args' => null,
+            'code' => Response::HTTP_OK,
+            'data' => [],
+        ];
+
+        yield 'respondWithSuccess(), default non-empty array' => [
+            'default' => ['message' => 'Task successful!'],
+            'args' => [],
+            'code' => Response::HTTP_OK,
+            'data' => ['message' => 'Task successful!'],
+        ];
+
+        yield 'respondWithSuccess(), default non-empty array, custom response data' => [
+            'default' => ['message' => 'Task successful!'],
+            'args' => ['numbers' => [1, 2, 3]],
+            'code' => Response::HTTP_OK,
+            'data' => ['numbers' => [1, 2, 3]],
         ];
     }
 }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -339,7 +339,7 @@ class ResponseTest extends TestCase
 			'respondAccepted',
 			[['role' => 'manager']],
 			Response::HTTP_ACCEPTED,
-			[],
+			['role' => 'manager'],
 		];
 
 		yield 'respondConflict(), no message' => [


### PR DESCRIPTION
- document fact that `respondNoContent()` method signature will change in future releases (per RFC 9110, a 204 response MUST NOT include content), add deprecated tag
- remove magic number from `apiResponse()` method signature
- use \Throwable instead of Exception (`morphMessage(string|Exception $message)` misses Error subclasses (TypeError, ValueError, etc.) - package is now PHP 8.2+, use string|\Throwable)
- fix indentation in `respondCreated()` and `respondTeapot()` methods
- fix `morphToArray()` method - `jsonSerialize()` returns mixed, not array `JsonSerializable::jsonSerialize()` has a return type of mixed in PHP 8.0+. If an object returns a scalar, the `?array` return type annotation is a lie and `apiResponse(array $data)` will throw a TypeError at runtime
- redundant null coalescing in `respondCreated()` and `respondNoContent()` methods
- additional helpers methods: `respondAccepted()`, `respondConflict()` and `respondTooManyRequests()` (with tests)
- refactor data providers within tests to use generators (better readability and memory usage)
- fix missing type hint for `testSuccessResponseDefaults()` within tests
- add missing tests cases for `respondAccepted()` method
- add missing tests cases for `respondFailedValidation()` method
- add missing tests cases for `respondNotFound()` method
- use version `^5.0` for the checkout and cache actions within the GitHub actions file