### PR TITLE
Add optional $key parameter to error responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,15 +62,15 @@ Returns a `200` HTTP status code, optionally `$contents` to return as json can b
 
 Returns a `200` HTTP status code
 
-#### `respondUnAuthenticated(?string $message = null)`
+#### `respondUnAuthenticated(?string $message = null, ?string $key = 'error')`
 
 Returns a `401` HTTP status code
 
-#### `respondForbidden(?string $message = null)`
+#### `respondForbidden(?string $message = null, ?string $key = 'error')`
 
 Returns a `403` HTTP status code
 
-#### `respondError(?string $message = null)`
+#### `respondError(?string $message = null, ?string $key = 'error')`
 
 Returns a `400` HTTP status code
 
@@ -86,11 +86,11 @@ Returns a `204` HTTP status code, with optional response data. Strictly speaking
 
 Returns a `202` HTTP status code, with response optional data
 
-#### ` public function respondConflict(?string $message = null)`
+#### ` public function respondConflict(?string $message = null, ?string $key = 'error')`
 
 Returns a `409` HTTP status code, with response optional message. If the message is omitted a default is sent
 
-#### `public function respondTooManyRequests(?string $message = null)`
+#### `public function respondTooManyRequests(?string $message = null, ?string $key = 'error')`
 
 Returns a `429` HTTP status code, with response optional message. If the message is omitted a default is sent
 

--- a/src/ApiResponseHelpers.php
+++ b/src/ApiResponseHelpers.php
@@ -52,26 +52,32 @@ trait ApiResponseHelpers
         return $this->respondWithSuccess(contents: ['success' => $message]);
     }
 
-    public function respondUnAuthenticated(?string $message = null): JsonResponse
-    {
+    public function respondUnAuthenticated(
+      ?string $message = null,
+      ?string $key = 'error'
+    ): JsonResponse {
         return $this->apiResponse(
-          data: ['error' => $message ?? 'Unauthenticated'],
+          data: [$key => $message ?? 'Unauthenticated'],
           code: Response::HTTP_UNAUTHORIZED
         );
     }
 
-    public function respondForbidden(?string $message = null): JsonResponse
-    {
+    public function respondForbidden(
+      ?string $message = null,
+      ?string $key = 'error'
+    ): JsonResponse {
         return $this->apiResponse(
-          data: ['error' => $message ?? 'Forbidden'],
+          data: [$key => $message ?? 'Forbidden'],
           code: Response::HTTP_FORBIDDEN
         );
     }
 
-    public function respondError(?string $message = null): JsonResponse
-    {
+    public function respondError(
+      ?string $message = null,
+      ?string $key = 'error'
+    ): JsonResponse {
         return $this->apiResponse(
-          data: ['error' => $message ?? 'Error'],
+          data: [$key => $message ?? 'Error'],
           code: Response::HTTP_BAD_REQUEST
         );
     }
@@ -133,18 +139,22 @@ trait ApiResponseHelpers
         );
     }
 
-    public function respondTooManyRequests(?string $message = null): JsonResponse
-    {
+    public function respondTooManyRequests(
+      ?string $message = null,
+      ?string $key = 'error'
+    ): JsonResponse {
         return $this->apiResponse(
-          data: ['error' => $message ?? 'Too Many Requests'],
+          data: [$key => $message ?? 'Too Many Requests'],
           code: Response::HTTP_TOO_MANY_REQUESTS
         );
     }
 
-    public function respondConflict(?string $message = null): JsonResponse
-    {
+    public function respondConflict(
+      ?string $message = null,
+      ?string $key = 'error'
+    ): JsonResponse {
         return $this->apiResponse(
-          data: ['error' => $message ?? 'Conflict'],
+          data: [$key => $message ?? 'Conflict'],
           code: Response::HTTP_CONFLICT
         );
     }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -197,6 +197,13 @@ class ResponseTest extends TestCase
           ['error' => 'Denied'],
         ];
 
+        yield 'respondUnAuthenticated(), custom key' => [
+          'respondUnAuthenticated',
+          ['Denied', 'message'],
+          Response::HTTP_UNAUTHORIZED,
+          ['message' => 'Denied'],
+        ];
+
         yield 'respondForbidden(), default message' => [
           'respondForbidden',
           [],
@@ -211,6 +218,13 @@ class ResponseTest extends TestCase
           ['error' => 'Disavowed'],
         ];
 
+        yield 'respondForbidden(), custom key' => [
+          'respondForbidden',
+          ['Disavowed', 'message'],
+          Response::HTTP_FORBIDDEN,
+          ['message' => 'Disavowed'],
+        ];
+
         yield 'respondError(), default message' => [
           'respondError',
           [],
@@ -223,6 +237,13 @@ class ResponseTest extends TestCase
           ['Order tampering detected'],
           Response::HTTP_BAD_REQUEST,
           ['error' => 'Order tampering detected'],
+        ];
+
+        yield 'respondError(), custom key' => [
+          'respondError',
+          ['Order tampering detected', 'message'],
+          Response::HTTP_BAD_REQUEST,
+          ['message' => 'Order tampering detected'],
         ];
 
         yield 'respondCreated()' => [
@@ -397,6 +418,13 @@ class ResponseTest extends TestCase
           Response::HTTP_CONFLICT,
           ['error' => 'Hmmm, conflicted ...'],
         ];
+
+        yield 'respondConflict(), custom key' => [
+          'respondConflict',
+          ['Hmmm, conflicted ...', 'message'],
+          Response::HTTP_CONFLICT,
+          ['message' => 'Hmmm, conflicted ...'],
+        ];
     
         yield 'respondTooManyRequests(), no message' => [
           'respondTooManyRequests',
@@ -410,6 +438,13 @@ class ResponseTest extends TestCase
           ['Spamming ...'],
           Response::HTTP_TOO_MANY_REQUESTS,
           ['error' => 'Spamming ...'],
+        ];
+
+        yield 'respondTooManyRequests(), custom key' => [
+          'respondTooManyRequests',
+          ['Spamming ...', 'message'],
+          Response::HTTP_TOO_MANY_REQUESTS,
+          ['message' => 'Spamming ...'],
         ];
     }
 


### PR DESCRIPTION
## Summary

Previously, the `respondNotFound` and `respondFailedValidation` methods contained an optional override for the message key.  However, this was not present in any of the other error responses.  This PR adds an optional `$key` parameter, which defaults to `error`, to the five remaining error responses, increasing consistency across the helper methods.  Additional test cases were also added testing custom keys with each updated method.  Method signatures have been updated in `README.md`.

As this is an optional last parameter that defaults to the original behavior, all existing test cases still pass, and changes are backwards compatible.

## Changes Made

- **src/ApiResponseHelpers.php**: Hardcoded `error` swapped for `$key` in `respondUnAuthenticated`, `respondForbidden`, `respondError`, `respondTooManyRequests`, and `respondConflict` methods, matching existing key override logic in `respondNotFound` and `respondFailedValidation`
- **tests/ResponseTest.php**: Added five new test cases, one per method, testing custom key behavior
- **README.md**: Updated signatures in altered methods to include new optional key parameter