### PR TITLE
Tighten GitHub Actions / Drop Laravel 11 Support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,18 +10,16 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.5, 8.4, 8.3, 8.2]
-        laravel: ["^13.12.0", "^12.61.1", "^11.0"]
+        laravel: ["^13.12.0", "^12.61.1"]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: ^13.12.0
             testbench: 11.*
           - laravel: ^12.61.1
             testbench: 10.*
-          - laravel: ^11.0
-            testbench: 9.*
         exclude:
-        - laravel: ^13.12.0
-          php: 8.2
+          - laravel: ^13.12.0
+            php: 8.2
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,18 +10,18 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.5, 8.4, 8.3, 8.2]
-        laravel: ["^13.0", "^12.0", "^11.0"]
+        laravel: ["^13.12.0", "^12.61.1", "^11.0"]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
-          - laravel: ^13.0
+          - laravel: ^13.12.0
             testbench: 11.*
-          - laravel: ^12.0
+          - laravel: ^12.61.1
             testbench: 10.*
           - laravel: ^11.0
             testbench: 9.*
         exclude:
-          - laravel: ^13.0
-            php: 8.2
+        - laravel: ^13.12.0
+          php: 8.2
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -48,10 +48,19 @@ jobs:
           extensions: curl, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, iconv
           coverage: none
 
+      - name: Validate composer.json
+        run: composer validate --strict --no-check-publish
+
+      - name: PHP lint
+        run: find src -name '*.php' -print0 | xargs -0 -n1 php -l
+
       - name: Install dependencies
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "symfony/console:>=4.3.4" "mockery/mockery:^1.3.2" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+
+      - name: Audit dependencies for known vulnerabilities
+        run: composer audit --locked --no-interaction
 
       - name: Display PHP version
         run: php -v | grep ^PHP | cut -d' ' -f2

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A simple package allowing for consistent API responses throughout your Laravel a
 ## Requirements
 
 - PHP `^8.2`
-- Laravel `^11.0`, `^12.0` or `^13.0`
+- Laravel `^12.0` or `^13.0`
 
 The package supports actively supported Laravel releases as per the official [Laravel Support Policy](https://laravel.com/docs/master/releases#support-policy).
 
@@ -160,10 +160,11 @@ return $this->respondCreated($resource);
 
 ## Legacy Support
 
-For PHP `^7.4` and Laravel `^6.0` / `^7.0` support, use package version [`^1.5`](https://github.com/f9webltd/laravel-api-response-helpers/tree/1.5.3).
+For PHP `^8.2` with Laravel `^11.0` support, use package version [`^3.1`](https://github.com/f9webltd/laravel-api-response-helpers/tree/3.1).
 
 For PHP `^8.0` with Laravel `^8.0`, `^9.0` and `^10.0` support use package version [`^2.1.1`](https://github.com/f9webltd/laravel-api-response-helpers/tree/2.1.1).
 
+For PHP `^7.4` and Laravel `^6.0` / `^7.0` support, use package version [`^1.5`](https://github.com/f9webltd/laravel-api-response-helpers/tree/1.5.3).
 
 ## Motivation
 

--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,10 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/support": "^11.0|^12.0|^13.0"
+        "illuminate/support": "^12.0|^13.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^9.0|^10.0|^11.0",
+        "orchestra/testbench": "^10.0|^11.0",
         "phpunit/phpunit": "^10.5|^11.0|^12.0"
     },
     "autoload": {


### PR DESCRIPTION
Add three new steps to the GitHub Actions workflow:

- **Composer validation** — checks `composer.json` is well-formed and strict
- **PHP lint** — runs a syntax check across all files in `src/`
- **Dependency audit** — flags any installed packages with known vulnerabilities

These are cheap, fast checks that catch real problems early:

- A malformed `composer.json` or syntax error will now fail the build immediately, before wasting time installing dependencies or running the full test suite
- The security audit means vulnerabilities in dependencies are caught automatically on every push, rather than discovered later in production

All three steps use built-in PHP/Composer tooling — no new dependencies required.

The validate and lint steps run after PHP is set up via `shivammathur/setup-php`, so they use the correct matrix PHP version rather than the runner default.

Due to composer audit output and the fact Laravel 11 is now officially EOL (see https://laravel.com/docs/13.x/releases#support-policy), this PR also drops Laravel 11 support.