### PR TITLE
Fix `respondNoContent` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ Returns a `400` HTTP status code
 
 Returns a `201` HTTP status code, with response optional data
 
-#### `respondNoContent(array|Arrayable|JsonSerializable|null $data = null)`
+#### `respondNoContent()`
 
-Returns a `204` HTTP status code, with optional response data. Strictly speaking, the response body should be empty. However, functionality to optionally return data was added to handle legacy projects. Within your own projects, you can simply call the method, omitting parameters, to generate a correct `204` response i.e. `return $this->respondNoContent()`
+Returns a `204` HTTP status code, with an empty response body (RFC 9110)
 
 #### `public function respondAccepted(array|Arrayable|JsonSerializable|null $data = null)`
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,14 @@
 # Upgrading
 
+## From 3.x to 4.x
+
+- Run the following command to fetch the latest package version: `composer require f9webltd/laravel-api-response-helpers:^4.0`
+- **Breaking change**: dropped support for Laravel 11. Laravel 11 reached end-of-life on 12/03/2026. This package now requires Laravel 12 or 13. See the [Laravel support policy](https://laravel.com/docs/master/releases#support-policy).
+- **Breaking change**: To comply with [RFC 9110](https://httpwg.org/specs/rfc9110.html#status.204), `respondNoContent()` no longer accepts arguments and no longer returns a `JsonResponse`. It now returns a `Symfony\Component\HttpFoundation\Response` with an empty body and a `204` status code. If `respondNoContent()` is not used in your codebase, no changes are needed. Otherwise:
+    - Remove any arguments passed to `$this->respondNoContent(...)`
+    - Update any `JsonResponse` return type hints to `Symfony\Component\HttpFoundation\Response`
+- No further changes are required, the API remains the same
+  
 ## From 2.x to 3.x
 
 - Run the following command to fetch the latest package version: `composer require f9webltd/laravel-api-response-helpers:^3.0`

--- a/src/ApiResponseHelpers.php
+++ b/src/ApiResponseHelpers.php
@@ -113,7 +113,7 @@ trait ApiResponseHelpers
      * Bypass apiResponse() and response()->json() entirely — a 204 response
      * must not include a body or Content-Type header per RFC 9110.
      */
-    public function respondNoContent(): JsonResponse
+    public function respondNoContent(): Response
     {
         return response('', Response::HTTP_NO_CONTENT);
     }

--- a/src/ApiResponseHelpers.php
+++ b/src/ApiResponseHelpers.php
@@ -109,25 +109,13 @@ trait ApiResponseHelpers
         );
     }
 
-    /**
-     * Per RFC 9110, a 204 response MUST NOT include content. Passing
-     * data to apiResponse() here violates the specification - any
-     * provided body is potentially ignored and can cause client
-     * errors. Functionality to return data here was added for legacy
-     * purposes only. In new projects call the method
-     * omitting any arguments
-     *
-     * @deprecated Will be removed in the next major release. The $data parameter
-     *             violates RFC 9110 — a 204 response MUST NOT include content.
-     *             Use respondNoContent() with no arguments.
+    /*
+     * Bypass apiResponse() and response()->json() entirely — a 204 response
+     * must not include a body or Content-Type header per RFC 9110.
      */
-    public function respondNoContent(
-      array|Arrayable|JsonSerializable|null $data = null
-    ): JsonResponse {
-        return $this->apiResponse(
-          data: $this->morphToArray(data: $data) ?? [],
-          code: Response::HTTP_NO_CONTENT
-        );
+    public function respondNoContent(): JsonResponse
+    {
+        return response('', Response::HTTP_NO_CONTENT);
     }
 
     public function respondAccepted(

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace F9Web\ApiResponseHelpers\Tests;
 
 use DomainException;
-use F9Web\ApiResponseHelpers;
 use F9Web\ApiResponseHelpers\Tests\Models\User;
 use F9Web\ApiResponseHelpers\Tests\Resources\UserResource;
 use Illuminate\Contracts\Support\Arrayable;
@@ -17,7 +16,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 
 use function json_encode;
 
-class ApiResponseService 
+class ApiResponseService
 {
     use \F9Web\ApiResponseHelpers;
 }
@@ -60,7 +59,17 @@ class ResponseTest extends TestCase
         self::assertJsonStringEqualsJsonString(json_encode($data, JSON_THROW_ON_ERROR), $response->getContent());
     }
 
-        public static function basicResponsesDataProvider(): iterable
+    public function testRespondNoContent(): void
+    {
+        /** @var \Symfony\Component\HttpFoundation\Response $response */
+        $response = $this->service->respondNoContent();
+        self::assertInstanceOf(Response::class, $response);
+        self::assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        self::assertSame('', $response->getContent());
+        self::assertFalse($response->headers->has('Content-Type'));
+    }
+
+    public static function basicResponsesDataProvider(): iterable
     {
         yield 'respondNotFound()' => [
           'respondNotFound',
@@ -339,44 +348,14 @@ class ResponseTest extends TestCase
           Response::HTTP_UNPROCESSABLE_ENTITY,
           ['error' => 'Invoice required'],
         ];
-		
+
         yield 'respondTeapot()' => [
           'respondTeapot',
           [],
           Response::HTTP_I_AM_A_TEAPOT,
           ['message' => 'I\'m a teapot'],
         ];
-        
-        yield 'respondNoContent()' => [
-          'respondNoContent',
-          [],
-          Response::HTTP_NO_CONTENT,
-          [],
-        ];
-        
-        yield 'respondNoContent() with null' => [
-          'respondNoContent',
-          [null],
-          Response::HTTP_NO_CONTENT,
-          [],
-        ];
-        
-        // @see https://github.com/f9webltd/laravel-api-response-helpers/issues/5#issuecomment-917418285
-        yield 'respondNoContent() with data' => [
-          'respondNoContent',
-          [['role' => 'manager']],
-          Response::HTTP_NO_CONTENT,
-          ['role' => 'manager'],
-        ];
-        
-        // @see https://github.com/f9webltd/laravel-api-response-helpers/issues/5#issuecomment-917418285
-        yield 'respondNoContent(), with collection as response' => [
-          'respondNoContent',
-          [new Collection(['invoice' => 23, 'status' => 'pending'])],
-          Response::HTTP_NO_CONTENT,
-          ['invoice' => 23, 'status' => 'pending'],
-        ];
-    
+
         yield 'respondAccepted() with data' => [
           'respondAccepted',
           [['role' => 'manager']],
@@ -390,7 +369,7 @@ class ResponseTest extends TestCase
           Response::HTTP_ACCEPTED,
           [],
         ];
-        
+
         yield 'respondAccepted() with null' => [
           'respondAccepted',
           [null],
@@ -411,7 +390,7 @@ class ResponseTest extends TestCase
           Response::HTTP_CONFLICT,
           ['error' => 'Conflict'],
         ];
-    
+
         yield 'respondConflict(), custom message' => [
           'respondConflict',
           ['Hmmm, conflicted ...'],
@@ -425,14 +404,14 @@ class ResponseTest extends TestCase
           Response::HTTP_CONFLICT,
           ['message' => 'Hmmm, conflicted ...'],
         ];
-    
+
         yield 'respondTooManyRequests(), no message' => [
           'respondTooManyRequests',
           [null],
           Response::HTTP_TOO_MANY_REQUESTS,
           ['error' => 'Too Many Requests'],
         ];
-    
+
         yield 'respondTooManyRequests(), custom message' => [
           'respondTooManyRequests',
           ['Spamming ...'],
@@ -451,38 +430,38 @@ class ResponseTest extends TestCase
     public static function successDefaultsDataProvider(): iterable
     {
         yield 'respondWithSuccess(), default empty array' => [
-            'default' => [],
-            'args' => [],
-            'code' => Response::HTTP_OK,
-            'data' => [],
+          'default' => [],
+          'args' => [],
+          'code' => Response::HTTP_OK,
+          'data' => [],
         ];
 
         yield 'respondWithSuccess(), default null' => [
-            'default' => null,
-            'args' => [],
-            'code' => Response::HTTP_OK,
-            'data' => [],
+          'default' => null,
+          'args' => [],
+          'code' => Response::HTTP_OK,
+          'data' => [],
         ];
 
         yield 'respondWithSuccess(), default null, null response' => [
-            'default' => null,
-            'args' => null,
-            'code' => Response::HTTP_OK,
-            'data' => [],
+          'default' => null,
+          'args' => null,
+          'code' => Response::HTTP_OK,
+          'data' => [],
         ];
 
         yield 'respondWithSuccess(), default non-empty array' => [
-            'default' => ['message' => 'Task successful!'],
-            'args' => [],
-            'code' => Response::HTTP_OK,
-            'data' => ['message' => 'Task successful!'],
+          'default' => ['message' => 'Task successful!'],
+          'args' => [],
+          'code' => Response::HTTP_OK,
+          'data' => ['message' => 'Task successful!'],
         ];
 
         yield 'respondWithSuccess(), default non-empty array, custom response data' => [
-            'default' => ['message' => 'Task successful!'],
-            'args' => ['numbers' => [1, 2, 3]],
-            'code' => Response::HTTP_OK,
-            'data' => ['numbers' => [1, 2, 3]],
+          'default' => ['message' => 'Task successful!'],
+          'args' => ['numbers' => [1, 2, 3]],
+          'code' => Response::HTTP_OK,
+          'data' => ['numbers' => [1, 2, 3]],
         ];
     }
 }


### PR DESCRIPTION
As per the commit at https://github.com/f9webltd/laravel-api-response-helpers/commit/9f91e203509d6393ef3a8fbc25f0964d4740df54, the `respondNoContent` previously returned a response body.

This commit ensures this method now follows RFC 9110, where HTTP 204 responses do not contain content / a body.